### PR TITLE
refactor: remove `saveSnapKeyring` argument from `handleKeyringSnapMessage`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 61.11,
-      functions: 63.64,
-      lines: 73.27,
-      statements: 73.27,
+      branches: 66.67,
+      functions: 72.73,
+      lines: 76,
+      statements: 76,
     },
   },
 

--- a/src/snap-keyring.test.ts
+++ b/src/snap-keyring.test.ts
@@ -12,8 +12,6 @@ describe('SnapKeyring', () => {
 
   const snapId = 'local:snap.mock';
 
-  const mockSaveSnapKeyring = jest.fn();
-
   const accounts = [
     {
       id: 'b05d918a-b37c-497a-bb28-3d15c0d56b7a',
@@ -40,12 +38,21 @@ describe('SnapKeyring', () => {
     // Fill the keyring with some accounts.
     for (const account of accounts) {
       mockSnapController.handleRequest.mockResolvedValueOnce(accounts);
-      await keyring.handleKeyringSnapMessage(
-        snapId,
-        ['create', account.address],
-        mockSaveSnapKeyring,
-      );
+      await keyring.handleKeyringSnapMessage(snapId, [
+        'create',
+        account.address,
+      ]);
     }
+  });
+
+  describe('handleKeyringSnapMessage', () => {
+    it('should return the list of accounts', async () => {
+      const expectedAccounts = accounts.map((a) => a.address);
+
+      mockSnapController.handleRequest.mockResolvedValueOnce(accounts);
+      const result = await keyring.handleKeyringSnapMessage(snapId, ['read']);
+      expect(result).toStrictEqual(expectedAccounts);
+    });
   });
 
   describe('getAccounts', () => {

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -77,14 +77,11 @@ export class SnapKeyring extends EventEmitter {
    *
    * @param snapId - ID of the snap.
    * @param message - Message sent by the snap.
-   * @param saveSnapKeyring - Function to save the snap's state.
    * @returns The execution result.
    */
   async handleKeyringSnapMessage(
     snapId: string,
     message: unknown,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    saveSnapKeyring: Function,
   ): Promise<Json> {
     assert(message, SnapMessageStruct);
     const [method, params] = message;
@@ -93,7 +90,6 @@ export class SnapKeyring extends EventEmitter {
       case 'delete':
       case 'create': {
         await this.#syncAccounts(snapId);
-        await saveSnapKeyring();
         return null;
       }
 

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -12,7 +12,7 @@ import EventEmitter from 'events';
 import { assert, object, string, record, Infer } from 'superstruct';
 import { v4 as uuid } from 'uuid';
 
-import { SnapMessageStruct } from './types';
+import { SnapMessage, SnapMessageStruct } from './types';
 import { DeferredPromise, strictMask, toJson, unique } from './util';
 
 export const SNAP_KEYRING_TYPE = 'Snap Keyring';
@@ -81,7 +81,7 @@ export class SnapKeyring extends EventEmitter {
    */
   async handleKeyringSnapMessage(
     snapId: string,
-    message: unknown,
+    message: SnapMessage,
   ): Promise<Json> {
     assert(message, SnapMessageStruct);
     const [method, params] = message;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 import { JsonStruct } from '@metamask/utils';
-import { Infer, string, tuple } from 'superstruct';
+import { Infer, string, tuple, union } from 'superstruct';
 
-export const SnapMessageStruct = tuple([string(), JsonStruct]);
+export const SnapMessageStruct = union([
+  tuple([string()]),
+  tuple([string(), JsonStruct]),
+]);
 
 /**
  * Message sent by the snap to manage accounts and requests.


### PR DESCRIPTION
This function will be called by the snap controller instead of the
bridge.