### PR TITLE
fix: fix circular read when handling `'read'` requests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 66.67,
-      functions: 72.73,
-      lines: 76,
-      statements: 76,
+      branches: 72.22,
+      functions: 78.26,
+      lines: 79,
+      statements: 79,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@metamask/snaps-controllers": "^0.34.1-flask.1",
     "@metamask/utils": "^6.1.0",
     "@types/uuid": "^9.0.1",
-    "eth-rpc-errors": "^4.0.3",
     "superstruct": "^1.0.3",
     "uuid": "^9.0.0"
   },

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -94,7 +94,12 @@ export class SnapKeyring extends EventEmitter {
       }
 
       case 'read': {
-        return await this.#listAccounts(snapId);
+        // Don't call the snap back to list the accounts. The main use case for
+        // this method is to allow the snap to verify if the keyring's state is
+        // in sync with the snap's state.
+        return Object.values(this.#addressToAccount).filter(
+          (account) => this.#addressToSnapId[account.address] === snapId,
+        );
       }
 
       case 'submit': {

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -7,7 +7,6 @@ import {
 } from '@metamask/keyring-api';
 import { SnapController } from '@metamask/snaps-controllers';
 import { Json } from '@metamask/utils';
-import { ethErrors } from 'eth-rpc-errors';
 import EventEmitter from 'events';
 import { assert, object, string, record, Infer } from 'superstruct';
 import { v4 as uuid } from 'uuid';
@@ -109,9 +108,7 @@ export class SnapKeyring extends EventEmitter {
       }
 
       default:
-        throw ethErrors.rpc.invalidParams({
-          message: 'Must specify a valid snap_manageAccounts "methodName".',
-        });
+        throw new Error(`Method not supported: ${method}`);
     }
   }
 
@@ -290,7 +287,7 @@ export class SnapKeyring extends EventEmitter {
    * @param _address - Address of the account to export.
    */
   exportAccount(_address: string): [Uint8Array, Json] | undefined {
-    throw new Error('snap-keyring: "exportAccount" not supported');
+    throw new Error('Exporting accounts from snaps is not supported');
   }
 
   /**

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -143,6 +143,10 @@ export class SnapKeyring extends EventEmitter {
    * @returns The list of account addresses.
    */
   getAccounts(): string[] {
+    // *** DO NOT CALL THE SNAP HERE ***
+    //
+    // This method has to be synchronous because it is called by the UI, for
+    // other use cases, use the `#listAccounts()` method instead.
     return unique(Object.keys(this.#addressToSnapId));
   }
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,15 @@
+import { DeferredPromise } from './util';
+
+describe('DeferredPromise', () => {
+  describe('constructor', () => {
+    it('should not fail to create a DeferredPromise', () => {
+      expect(() => new DeferredPromise()).not.toThrow();
+    });
+
+    it('should define resolve and reject fields', () => {
+      const promise = new DeferredPromise();
+      expect(promise.resolve).toBeDefined();
+      expect(promise.reject).toBeDefined();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,7 +2053,6 @@ __metadata:
     eslint-plugin-jsdoc: ^39.6.2
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
-    eth-rpc-errors: ^4.0.3
     jest: ^28.1.3
     jest-it-up: ^2.0.2
     prettier: ^2.7.1


### PR DESCRIPTION
When a snap calls the `'read'` method, the main use case is to allow the snap to detect any synchronization problems between it and the bridge.

This PR makes sure that we return the accounts from the bridge's state instead of calling back the snap.