### PR TITLE
chore: don't sync accounts twice on deletion

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,8 +43,8 @@ module.exports = {
     global: {
       branches: 72.22,
       functions: 78.26,
-      lines: 79,
-      statements: 79,
+      lines: 79.79,
+      statements: 79.79,
     },
   },
 

--- a/src/snap-keyring.ts
+++ b/src/snap-keyring.ts
@@ -304,7 +304,6 @@ export class SnapKeyring extends EventEmitter {
     delete this.#addressToSnapId[address];
 
     await this.#snapClient.withSnapId(snapId).deleteAccount(account.id);
-    await this.#syncAccounts();
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,7 +1363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.0":
+"@noble/hashes@npm:1.3.0, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.1.3, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:~1.3.0":
   version: 1.3.0
   resolution: "@noble/hashes@npm:1.3.0"
   checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,7 +1363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.0, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.1.3, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:~1.3.0":
+"@noble/hashes@npm:1.3.0":
   version: 1.3.0
   resolution: "@noble/hashes@npm:1.3.0"
   checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e


### PR DESCRIPTION
The syncronization is already done once the snap notifies the keyring controller.