### PR TITLE
fix: remove promise if `submitRequest()` throws

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.21,
-      functions: 94.11,
-      lines: 95,
-      statements: 95,
+      branches: 89.47,
+      functions: 94.28,
+      lines: 95.96,
+      statements: 95.96,
     },
   },
 


### PR DESCRIPTION
This PR fixes a leak in the deferred promises when the call to `submitRequest()` throws an exception.