### PR TITLE
feat: add `removeAccount` callback to constructor

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -58,3 +58,12 @@ export function ensureDefined<Type>(
     throw new Error('Argument is undefined');
   }
 }
+
+/**
+ * Helper function that throws an error.
+ *
+ * @param message - Error message to throw.
+ */
+export function throwError(message: string): never {
+  throw new Error(message);
+}


### PR DESCRIPTION
This PR adds a `removeAccount` callback to the `SnapKeyring` that will be called when the snap notify us that it deleted an account.