### PR TITLE
feat: handle approval when adding/removing account

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -167,19 +167,11 @@ describe('SnapKeyring', () => {
     });
 
     it('removes an account', async () => {
-<<<<<<< HEAD
       mockSnapController.handleRequest.mockResolvedValue(null);
-      mockCallbacks.removeAccount.mockImplementation(async (address) => {
+      mockCallbacks.removeAccount.mockImplementation(async (address, handleUserInput) => {
+        await handleUserInput(true);
         await keyring.removeAccount(address);
       });
-=======
-      mockCallbacks.removeAccount.mockImplementation(
-        async (_address, _snapId, handleUserInput) => {
-          await handleUserInput(true);
-        },
-      );
->>>>>>> 0cf64cf (test: mock `addAccount` and `removeAccount` callbacks in the unit tests)
-
       await keyring.handleKeyringSnapMessage(snapId, {
         method: KeyringEvent.AccountDeleted,
         params: { id: accounts[0].id },
@@ -211,6 +203,21 @@ describe('SnapKeyring', () => {
           params: { id: 'bcda5b5f-098f-4706-919b-ee919402f0dd' },
         }),
       ).toBeNull();
+    });
+
+    it('throws an error if the removeAccount callback fails', async () => {
+      mockCallbacks.removeAccount.mockImplementation(
+        async (_address, _snapId, _handleUserInput) => {
+          throw new Error('Some error occurred while removing account');
+        },
+      );
+
+      await expect(
+        keyring.handleKeyringSnapMessage(snapId, {
+          method: KeyringEvent.AccountDeleted,
+          params: { id: accounts[0].id },
+        }),
+      ).rejects.toThrow('Some error occurred while removing account');
     });
 
     it('fails when the method is not supported', async () => {
@@ -379,6 +386,27 @@ describe('SnapKeyring', () => {
       await expect(responsePromise).rejects.toThrow(
         "Request 'b59b5449-5517-4622-99f2-82670cc7f3f3' not found",
       );
+    it('returns null after successfully updating an account', async () => {
+      const result = await keyring.handleKeyringSnapMessage(snapId, {
+        method: KeyringEvent.AccountUpdated,
+      });
+      expect(mockCallbacks.saveState).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+    });
+
+    it('throws an error if updating account fails', async () => {
+      mockCallbacks.saveState.mockImplementation(
+        async (_address, _snapId, _handleUserInput) => {
+          throw new Error('Some error occurred while updating account');
+        },
+      );
+
+      await expect(
+        keyring.handleKeyringSnapMessage(snapId, {
+          method: KeyringEvent.AccountUpdated,
+          params: { id: accounts[0].id },
+        }),
+      ).rejects.toThrow('Some error occurred while updating account');
     });
   });
 

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -18,8 +18,15 @@ describe('SnapKeyring', () => {
 
   const mockCallbacks = {
     saveState: jest.fn(),
-    removeAccount: jest.fn(),
     addressExists: jest.fn(),
+    addAccount: jest.fn(async (_address, _snapId, handleUserInput) => {
+      await handleUserInput(true);
+      return Promise.resolve();
+    }),
+    removeAccount: jest.fn(async (_address, _snapId, handleUserInput) => {
+      await handleUserInput(true);
+      return Promise.resolve();
+    }),
   };
 
   const snapId = 'local:snap.mock';

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -53,6 +53,11 @@ describe('SnapKeyring', () => {
       mockSnapController as unknown as SnapController,
       mockCallbacks,
     );
+    mockCallbacks.addAccount.mockImplementation(
+      async (_address, _snapId, handleUserInput) => {
+        await handleUserInput(true);
+      },
+    );
     for (const account of accounts) {
       mockSnapController.handleRequest.mockResolvedValue(accounts);
       await keyring.handleKeyringSnapMessage(snapId, {
@@ -162,10 +167,18 @@ describe('SnapKeyring', () => {
     });
 
     it('removes an account', async () => {
+<<<<<<< HEAD
       mockSnapController.handleRequest.mockResolvedValue(null);
       mockCallbacks.removeAccount.mockImplementation(async (address) => {
         await keyring.removeAccount(address);
       });
+=======
+      mockCallbacks.removeAccount.mockImplementation(
+        async (_address, _snapId, handleUserInput) => {
+          await handleUserInput(true);
+        },
+      );
+>>>>>>> 0cf64cf (test: mock `addAccount` and `removeAccount` callbacks in the unit tests)
 
       await keyring.handleKeyringSnapMessage(snapId, {
         method: KeyringEvent.AccountDeleted,

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -23,7 +23,8 @@ describe('SnapKeyring', () => {
       await handleUserInput(true);
       return Promise.resolve();
     }),
-    removeAccount: jest.fn(async (_address, _snapId, handleUserInput) => {
+    removeAccount: jest.fn(async (address, _snapId, handleUserInput) => {
+      await keyring.removeAccount(address);
       await handleUserInput(true);
       return Promise.resolve();
     }),
@@ -168,10 +169,13 @@ describe('SnapKeyring', () => {
 
     it('removes an account', async () => {
       mockSnapController.handleRequest.mockResolvedValue(null);
-      mockCallbacks.removeAccount.mockImplementation(async (address, handleUserInput) => {
-        await handleUserInput(true);
-        await keyring.removeAccount(address);
-      });
+      mockCallbacks.removeAccount.mockImplementation(
+        async (address, _snapId, handleUserInput) => {
+          await keyring.removeAccount(address);
+          await handleUserInput(true);
+        },
+      );
+
       await keyring.handleKeyringSnapMessage(snapId, {
         method: KeyringEvent.AccountDeleted,
         params: { id: accounts[0].id },
@@ -203,21 +207,6 @@ describe('SnapKeyring', () => {
           params: { id: 'bcda5b5f-098f-4706-919b-ee919402f0dd' },
         }),
       ).toBeNull();
-    });
-
-    it('throws an error if the removeAccount callback fails', async () => {
-      mockCallbacks.removeAccount.mockImplementation(
-        async (_address, _snapId, _handleUserInput) => {
-          throw new Error('Some error occurred while removing account');
-        },
-      );
-
-      await expect(
-        keyring.handleKeyringSnapMessage(snapId, {
-          method: KeyringEvent.AccountDeleted,
-          params: { id: accounts[0].id },
-        }),
-      ).rejects.toThrow('Some error occurred while removing account');
     });
 
     it('fails when the method is not supported', async () => {
@@ -386,27 +375,30 @@ describe('SnapKeyring', () => {
       await expect(responsePromise).rejects.toThrow(
         "Request 'b59b5449-5517-4622-99f2-82670cc7f3f3' not found",
       );
-    it('returns null after successfully updating an account', async () => {
-      const result = await keyring.handleKeyringSnapMessage(snapId, {
-        method: KeyringEvent.AccountUpdated,
-      });
-      expect(mockCallbacks.saveState).toHaveBeenCalledTimes(1);
-      expect(result).toBeNull();
     });
 
-    it('throws an error if updating account fails', async () => {
-      mockCallbacks.saveState.mockImplementation(
+    it('throws an error if the removeAccount callback fails', async () => {
+      mockCallbacks.removeAccount.mockImplementation(
         async (_address, _snapId, _handleUserInput) => {
-          throw new Error('Some error occurred while updating account');
+          throw new Error('Some error occurred while removing account');
         },
       );
 
       await expect(
         keyring.handleKeyringSnapMessage(snapId, {
-          method: KeyringEvent.AccountUpdated,
+          method: KeyringEvent.AccountDeleted,
           params: { id: accounts[0].id },
         }),
-      ).rejects.toThrow('Some error occurred while updating account');
+      ).rejects.toThrow('Some error occurred while removing account');
+    });
+
+    it('returns null after successfully updating an account', async () => {
+      const result = await keyring.handleKeyringSnapMessage(snapId, {
+        method: KeyringEvent.AccountUpdated,
+        params: { account: accounts[0] as unknown as KeyringAccount },
+      });
+      expect(mockCallbacks.saveState).toHaveBeenCalled();
+      expect(result).toBeNull();
     });
   });
 

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -68,6 +68,14 @@ export type SnapKeyringCallbacks = {
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
+<<<<<<< HEAD
+=======
+  removeAccount(
+    address: string,
+    snapId: string,
+    handleUserInput: (accepted: boolean) => Promise<void>,
+  ): Promise<void>;
+>>>>>>> 3959cec (add `handleUserInput` callback to `removeAccount`)
 };
 
 /**

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -60,7 +60,7 @@ export type KeyringState = Infer<typeof KeyringStateStruct>;
  * These callbacks are used to interact with other components.
  */
 export type SnapKeyringCallbacks = {
-  saveState: () => Promise<void>;
+  saveState: (origin: string) => Promise<void>;
   removeAccount(address: string): Promise<void>;
   addressExists(address: string): Promise<boolean>;
 };
@@ -294,7 +294,6 @@ export class SnapKeyring extends EventEmitter {
       case KeyringEvent.AccountUpdated: {
         return this.#handleAccountUpdated(snapId, message);
       }
-
       case KeyringEvent.AccountDeleted: {
         return this.#handleAccountDeleted(snapId, message);
       }

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -61,21 +61,17 @@ export type KeyringState = Infer<typeof KeyringStateStruct>;
  */
 export type SnapKeyringCallbacks = {
   saveState: () => Promise<void>;
-  removeAccount(address: string): Promise<void>;
   addressExists(address: string): Promise<boolean>;
   addAccount(
     address: string,
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
-<<<<<<< HEAD
-=======
   removeAccount(
     address: string,
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
->>>>>>> 3959cec (add `handleUserInput` callback to `removeAccount`)
 };
 
 /**

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -60,9 +60,14 @@ export type KeyringState = Infer<typeof KeyringStateStruct>;
  * These callbacks are used to interact with other components.
  */
 export type SnapKeyringCallbacks = {
-  saveState: (origin: string) => Promise<void>;
+  saveState: () => Promise<void>;
   removeAccount(address: string): Promise<void>;
   addressExists(address: string): Promise<boolean>;
+  addAccount(
+    address: string,
+    snapId: string,
+    handleUserInput: (accepted: boolean) => Promise<void>,
+  ): Promise<void>;
 };
 
 /**

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -227,7 +227,7 @@ export class SnapKeyring extends EventEmitter {
       throw new Error(`Cannot delete account '${id}'`);
     }
 
-    await this.#callbacks.removeAccount(address.toLowerCase());
+    await this.#callbacks.removeAccount(address.toLowerCase(), snapId);
     return null;
   }
 


### PR DESCRIPTION
works alongside this PR in the extension: https://github.com/MetaMask/metamask-extension/pull/20684

follow steps outlined in the linked extension PR to test

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
