### PR TITLE
fix: ignore event if account was already removed

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -69,19 +69,17 @@ describe('SnapKeyring', () => {
       ]);
     });
 
-    it('throws when removing an account that does not exist', async () => {
+    it('returns null when removing an account that does not exist', async () => {
       mockCallbacks.removeAccount.mockImplementation(async (address) => {
         await keyring.removeAccount(address);
       });
 
-      await expect(
-        keyring.handleKeyringSnapMessage(snapId, {
+      expect(
+        await keyring.handleKeyringSnapMessage(snapId, {
           method: KeyringEvent.AccountDeleted,
           params: { id: 'bcda5b5f-098f-4706-919b-ee919402f0dd' },
         }),
-      ).rejects.toThrow(
-        "Account 'bcda5b5f-098f-4706-919b-ee919402f0dd' not found",
-      );
+      ).toBeNull();
     });
 
     it('fails when the method is not supported', async () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,4 +1,4 @@
-import { ensureDefined, toJson, unique } from './util';
+import { ensureDefined, throwError, toJson, unique } from './util';
 
 describe('unique', () => {
   it('returns an empty array when given an empty array', () => {
@@ -50,5 +50,11 @@ describe('ensureDefined', () => {
 
   it('throws an error when value is undefined', () => {
     expect(() => ensureDefined(undefined)).toThrow('Argument is undefined');
+  });
+});
+
+describe('throwError', () => {
+  it('throws an error with the given message', () => {
+    expect(() => throwError('hello')).toThrow('hello');
   });
 });


### PR DESCRIPTION
When an account is removed using MetaMask's UI, we remove the account from the keyring, and then we call the snap to delete the account. It's done this way to ensure that the account is always removed from MetaMask, even if the snap fails.

As a consequence, when the snap notifies the keyring that it has removed the account, the account no longer in the keyring, which throws an error.

This PR changes this behavior and ignores the `AccountDeleted` event in case the account doesn't exist in the keyring.