### PR TITLE
bump @metamask/keyring-api to v0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/keyring-api": "^0.2.3",
+    "@metamask/keyring-api": "^0.2.5",
     "@metamask/snaps-controllers": "^0.38.2-flask.1",
     "@metamask/utils": "^8.1.0",
     "@types/uuid": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/keyring-api": ^0.2.3
+    "@metamask/keyring-api": ^0.2.5
     "@metamask/snaps-controllers": ^0.38.2-flask.1
     "@metamask/utils": ^8.1.0
     "@types/jest": ^28.1.6
@@ -1120,7 +1120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^0.2.3":
+"@metamask/keyring-api@npm:^0.2.5":
   version: 0.2.5
   resolution: "@metamask/keyring-api@npm:0.2.5"
   dependencies:


### PR DESCRIPTION
Trying to align our `@metamask/providers` version in extension. Need to bump `@metamask/keyring-api` to 0.2.5 where [providers is bumped to 13.0.0](https://github.com/MetaMask/keyring-api/compare/v0.2.4...v0.2.5#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)

* See: https://github.com/MetaMask/metamask-extension/pull/20917

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
