### PR TITLE
fix: prevent duplicate address from being added

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/keyring-api": "^0.2.6",
+    "@metamask/keyring-api": "github:MetaMask/keyring-api#37c0e66548194607ed0715ce0f1abe9665ff3adc",
     "@metamask/snaps-controllers": "^2.0.0",
     "@metamask/utils": "^8.1.0",
     "@types/uuid": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/keyring-api": "^0.2.5",
-    "@metamask/snaps-controllers": "^0.38.2-flask.1",
+    "@metamask/keyring-api": "^0.2.6",
+    "@metamask/snaps-controllers": "^2.0.0",
     "@metamask/utils": "^8.1.0",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",

--- a/src/CaseInsensitiveMap.test.ts
+++ b/src/CaseInsensitiveMap.test.ts
@@ -1,7 +1,7 @@
 import { CaseInsensitiveMap } from './CaseInsensitiveMap';
 
 describe('CaseInsensitiveMap', () => {
-  it('should set and get values case-insensitively', () => {
+  it('sets and gets values case-insensitively', () => {
     const map = new CaseInsensitiveMap<number>();
     map.set('foo', 1);
     map.set('BAR', 2);
@@ -11,7 +11,7 @@ describe('CaseInsensitiveMap', () => {
     expect(map.get('BaR')).toBe(2);
   });
 
-  it('should check for keys case-insensitively', () => {
+  it('checks for keys case-insensitively', () => {
     const map = new CaseInsensitiveMap<number>();
     map.set('foo', 1);
     expect(map.has('foo')).toBe(true);
@@ -20,7 +20,7 @@ describe('CaseInsensitiveMap', () => {
     expect(map.has('BaR')).toBe(false);
   });
 
-  it('should delete keys case-insensitively', () => {
+  it('deletes keys case-insensitively', () => {
     const map = new CaseInsensitiveMap<number>();
     map.set('foo', 1);
     map.set('BAR', 2);
@@ -34,7 +34,7 @@ describe('CaseInsensitiveMap', () => {
     expect(map.has('BaR')).toBe(false);
   });
 
-  it('should be able to construct from items', () => {
+  it('is able to construct from items', () => {
     const map = new CaseInsensitiveMap<number>([
       ['foo', 1],
       ['BAR', 2],
@@ -45,7 +45,7 @@ describe('CaseInsensitiveMap', () => {
     expect(map.get('BaR')).toBe(2);
   });
 
-  it('should convert the map to an object', () => {
+  it('converts the map to an object', () => {
     const map = new CaseInsensitiveMap<number>([
       ['foo', 1],
       ['BAR', 2],
@@ -54,12 +54,17 @@ describe('CaseInsensitiveMap', () => {
     expect(obj).toStrictEqual({ foo: 1, bar: 2 });
   });
 
-  it('should create a map from an object', () => {
+  it('creates a map from an object', () => {
     const obj = { foo: 1, BAR: 2 };
     const map = CaseInsensitiveMap.fromObject(obj);
     expect(map.get('foo')).toBe(1);
     expect(map.get('FOO')).toBe(1);
     expect(map.get('bar')).toBe(2);
     expect(map.get('BaR')).toBe(2);
+  });
+
+  it('throws an error when trying to get a non-existent key', () => {
+    const map = new CaseInsensitiveMap<number>();
+    expect(() => map.getOrThrow('foo')).toThrow("Key 'foo' not found");
   });
 });

--- a/src/CaseInsensitiveMap.ts
+++ b/src/CaseInsensitiveMap.ts
@@ -1,3 +1,5 @@
+import { throwError } from './util';
+
 /**
  * A case-insensitive map that stores key-value pairs.
  */
@@ -44,11 +46,7 @@ export class CaseInsensitiveMap<Value> extends Map<string, Value> {
    * @returns The value associated with the given key.
    */
   getOrThrow(key: string, name = 'Key'): Value {
-    const value = this.get(key);
-    if (value === undefined) {
-      throw new Error(`${name} '${key}' not found`);
-    }
-    return value;
+    return this.get(key) ?? throwError(`${name} '${key}' not found`);
   }
 
   /**

--- a/src/DeferredPromise.ts
+++ b/src/DeferredPromise.ts
@@ -21,7 +21,7 @@ export class DeferredPromise<Type> {
     });
 
     // This is a sanity check to make sure that the promise constructor
-    // actually set the resolve and reject functions.
+    // actually set the `resolve` and `reject` functions.
     /* istanbul ignore next */
     if (!this.resolve || !this.reject) {
       throw new Error('Promise constructor failed');

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -89,9 +89,16 @@ describe('SnapKeyring', () => {
       await expect(
         keyring.handleKeyringSnapMessage(snapId, {
           method: KeyringEvent.AccountUpdated,
-          params: { account: { id: 'some-invalid-id' } },
+          params: {
+            account: {
+              ...(accounts[0] as unknown as KeyringAccount),
+              id: '0b3551da-1685-4750-ad4c-01fc3a9e90b1',
+            },
+          },
         }),
-      ).rejects.toThrow("Account 'some-invalid-id' not found");
+      ).rejects.toThrow(
+        "Account '0b3551da-1685-4750-ad4c-01fc3a9e90b1' not found",
+      );
     });
 
     it('cannot change the address of an account', async () => {
@@ -99,7 +106,10 @@ describe('SnapKeyring', () => {
         keyring.handleKeyringSnapMessage(snapId, {
           method: KeyringEvent.AccountUpdated,
           params: {
-            account: { id: accounts[0].id, address: accounts[1].address },
+            account: {
+              ...(accounts[0] as unknown as KeyringAccount),
+              address: accounts[1].address,
+            },
           },
         }),
       ).rejects.toThrow(
@@ -112,7 +122,9 @@ describe('SnapKeyring', () => {
         keyring.handleKeyringSnapMessage('invalid-snap-id', {
           method: KeyringEvent.AccountUpdated,
           params: {
-            account: { id: accounts[0].id, address: accounts[0].address },
+            account: {
+              ...(accounts[0] as unknown as KeyringAccount),
+            },
           },
         }),
       ).rejects.toThrow(

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -618,28 +618,5 @@ describe('SnapKeyring', () => {
       }));
       expect(result).toStrictEqual(expected);
     });
-
-    it('continues to list account even if one fails', async () => {
-      mockSnapController.handleRequest.mockImplementation(() => {
-        throw new Error('error');
-      });
-      const expected = accounts.map((a) => ({
-        ...a,
-        metadata: {
-          name: '',
-          keyring: {
-            type: 'Snap Keyring',
-          },
-        },
-      }));
-      const spy = jest.spyOn(console, 'error').mockImplementation();
-      const result = await keyring.listAccounts();
-      expect(console.error).toHaveBeenCalledWith(
-        "Failed to sync accounts for snap 'local:snap.mock':",
-        expect.any(Error),
-      );
-      expect(result).toStrictEqual(expected);
-      spy.mockRestore();
-    });
   });
 });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -121,6 +121,7 @@ describe('SnapKeyring', () => {
     });
 
     it('removes an account', async () => {
+      mockSnapController.handleRequest.mockResolvedValue(null);
       mockCallbacks.removeAccount.mockImplementation(async (address) => {
         await keyring.removeAccount(address);
       });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -147,6 +147,17 @@ describe('SnapKeyring', () => {
       ]);
     });
 
+    it('cannot delete an account owned by another snap', async () => {
+      await expect(
+        keyring.handleKeyringSnapMessage('invalid-snap-id', {
+          method: KeyringEvent.AccountDeleted,
+          params: { id: accounts[0].id },
+        }),
+      ).rejects.toThrow(
+        "Cannot delete account 'b05d918a-b37c-497a-bb28-3d15c0d56b7a'",
+      );
+    });
+
     it('returns null when removing an account that does not exist', async () => {
       mockCallbacks.removeAccount.mockImplementation(async (address) => {
         await keyring.removeAccount(address);

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -649,15 +649,15 @@ describe('SnapKeyring', () => {
     });
 
     it('removes the account and warn if snap fails', async () => {
-      const spy = jest.spyOn(console, 'error').mockImplementation();
-      mockSnapController.handleRequest.mockRejectedValue('error');
+      const spy = jest.spyOn(console, 'warn').mockImplementation();
+      mockSnapController.handleRequest.mockRejectedValue('some error');
       await keyring.removeAccount(accounts[0].address);
       expect(await keyring.getAccounts()).toStrictEqual([
         accounts[1].address.toLowerCase(),
       ]);
-      expect(console.error).toHaveBeenCalledWith(
-        'Account "0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3" may not have been removed from snap "local:snap.mock":',
-        'error',
+      expect(console.warn).toHaveBeenCalledWith(
+        "Account '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3' may not have been removed from snap 'local:snap.mock':",
+        'some error',
       );
       spy.mockRestore();
     });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -56,14 +56,36 @@ describe('SnapKeyring', () => {
   });
 
   describe('handleKeyringSnapMessage', () => {
-    it('throws if we try to add an account that already exists', async () => {
+    it('cannot add an account that already exists (address)', async () => {
       mockCallbacks.addressExists.mockResolvedValue(true);
       await expect(
         keyring.handleKeyringSnapMessage(snapId, {
           method: KeyringEvent.AccountCreated,
-          params: { account: accounts[0] as unknown as KeyringAccount },
+          params: {
+            account: {
+              ...(accounts[0] as unknown as KeyringAccount),
+              id: 'c6697bcf-5710-4751-a1cb-340e4b50617a',
+            },
+          },
         }),
-      ).rejects.toThrow(`Account '${accounts[0].address}' already exists`);
+      ).rejects.toThrow(
+        `Account address '${accounts[0].address}' already exists`,
+      );
+    });
+
+    it('cannot add an account that already exists (ID)', async () => {
+      mockCallbacks.addressExists.mockResolvedValue(false);
+      await expect(
+        keyring.handleKeyringSnapMessage(snapId, {
+          method: KeyringEvent.AccountCreated,
+          params: {
+            account: {
+              ...(accounts[0] as unknown as KeyringAccount),
+              address: '0x0',
+            },
+          },
+        }),
+      ).rejects.toThrow(`Account ID '${accounts[0].id}' already exists`);
     });
 
     it('updated the methods of an account', async () => {

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -46,14 +46,29 @@ export class SnapKeyring extends EventEmitter {
 
   type: string;
 
+  /**
+   * Client used to call the snap keyring.
+   */
   #snapClient: KeyringSnapControllerClient;
 
+  /**
+   * Mapping between account addresses and account objects.
+   */
   #addressToAccount: CaseInsensitiveMap<KeyringAccount>;
 
+  /**
+   * Mapping between account addresses and snap IDs.
+   */
   #addressToSnapId: CaseInsensitiveMap<string>;
 
+  /**
+   * Mapping between request IDs and their deferred promises.
+   */
   #pendingRequests: CaseInsensitiveMap<DeferredPromise<any>>;
 
+  /**
+   * Callbacks used by the snap keyring to interact with other components.
+   */
   #callbacks: SnapKeyringCallbacks;
 
   constructor(controller: SnapController, callbacks: SnapKeyringCallbacks) {
@@ -491,6 +506,12 @@ export class SnapKeyring extends EventEmitter {
     );
   }
 
+  /**
+   * Get the metadata of a snap keyring account.
+   *
+   * @param address - Account address.
+   * @returns The snap metadata or undefined if the snap cannot be found.
+   */
   #getSnapMetadata(
     address: string,
   ): InternalAccount['metadata']['snap'] | undefined {

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -232,7 +232,7 @@ export class SnapKeyring extends EventEmitter {
     const { id, result } = message.params;
     const { promise, snapId: expectedSnapId } = this.#requests.getOrThrow(
       id,
-      'Pending request',
+      'Request',
     );
 
     // ! A snap cannot approve a request it didn't receive.
@@ -260,7 +260,7 @@ export class SnapKeyring extends EventEmitter {
     const { id } = message.params;
     const { promise, snapId: expectedSnapId } = this.#requests.getOrThrow(
       id,
-      'Pending request',
+      'Request',
     );
 
     // ! A snap cannot reject a request it didn't receive.

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -355,8 +355,8 @@ export class SnapKeyring extends EventEmitter {
       return response.result;
     }
 
-    // TODO: In the future, this should be handled by the UI. For now, we just
-    // log the redirect information for debugging purposes.
+    // In the future, this should be handled by the UI. For now, we just log
+    // the redirect information for debugging purposes.
     if (response.redirect?.message || response.redirect?.url) {
       const { message = '', url = '' } = response.redirect;
       console.log(

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -111,7 +111,13 @@ export class SnapKeyring extends EventEmitter {
     // to block the creation of duplicate accounts for now to prevent accounts
     // from being overwritten.
     if (await this.#callbacks.addressExists(account.address)) {
-      throw new Error(`Account '${account.address}' already exists`);
+      throw new Error(`Account address '${account.address}' already exists`);
+    }
+
+    // A snap could try to create an account with a different address but with
+    // an existing ID, so the above test only is not enough.
+    if (this.#getAccountById(account.id) !== undefined) {
+      throw new Error(`Account ID '${account.id}' already exists`);
     }
 
     this.#addAccountToMaps(account, snapId);

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -107,9 +107,9 @@ export class SnapKeyring extends EventEmitter {
     assert(message, AccountCreatedEventStruct);
     const { account } = message.params;
 
-    // TODO: The UI still uses the account address to identify accounts, so
-    // we need to block the creation of duplicate accounts for now to
-    // prevent accounts from being overwritten.
+    // The UI still uses the account address to identify accounts, so we need
+    // to block the creation of duplicate accounts for now to prevent accounts
+    // from being overwritten.
     if (await this.#callbacks.addressExists(account.address)) {
       throw new Error(`Account '${account.address}' already exists`);
     }

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -200,7 +200,6 @@ export class SnapKeyring extends EventEmitter {
 
     this.#pendingRequests.delete(id);
     promise.resolve(result);
-
     return null;
   }
 
@@ -217,7 +216,6 @@ export class SnapKeyring extends EventEmitter {
 
     this.#pendingRequests.delete(id);
     promise.reject(new Error(`Request rejected by user or snap.`));
-
     return null;
   }
 

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -46,8 +46,19 @@ export const KeyringStateStruct = object({
   ),
 });
 
+/**
+ * Snap keyring state.
+ *
+ * This state is persisted by the keyring controller and passed to the snap
+ * keyring when it's created.
+ */
 export type KeyringState = Infer<typeof KeyringStateStruct>;
 
+/**
+ * Snap keyring callbacks.
+ *
+ * These callbacks are used to interact with other components.
+ */
 export type SnapKeyringCallbacks = {
   saveState: () => Promise<void>;
   removeAccount(address: string): Promise<void>;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -216,7 +216,7 @@ export class SnapKeyring extends EventEmitter {
     const { promise, snapId: expectedSnapId } =
       this.#pendingRequests.getOrThrow(id, 'Pending request');
 
-    // ! A snap cannot approve a request it didn't create.
+    // ! A snap cannot approve a request it didn't receive.
     if (snapId !== expectedSnapId) {
       throw new Error(`Cannot approve request '${id}'`);
     }
@@ -242,7 +242,7 @@ export class SnapKeyring extends EventEmitter {
     const { promise, snapId: expectedSnapId } =
       this.#pendingRequests.getOrThrow(id, 'Pending request');
 
-    // ! A snap cannot reject a request it didn't create.
+    // ! A snap cannot reject a request it didn't receive.
     if (snapId !== expectedSnapId) {
       throw new Error(`Cannot reject request '${id}'`);
     }

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -598,6 +598,20 @@ export class SnapKeyring extends EventEmitter {
   }
 
   /**
+   * Remove all accounts associated with a given Snap ID.
+   *
+   * @param snapId - The Snap ID to remove accounts for.
+   * @returns A Promise that resolves when all accounts have been removed.
+   */
+  async removeAccountsBySnapId(snapId: string): Promise<void> {
+    for (const entry of this.#accounts.values()) {
+      if (entry.snapId === snapId) {
+        await this.removeAccount(entry.account.address);
+      }
+    }
+  }
+
+  /**
    * List all snap keyring accounts.
    *
    * @returns An array containing all snap keyring accounts.

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -323,7 +323,7 @@ export class SnapKeyring extends EventEmitter {
    */
   async getAccounts(): Promise<string[]> {
     return unique(
-      Array.from(this.#accounts.values()).map((entry) => entry.account.address),
+      Array.from(this.#accounts.values()).map(({ account }) => account.address),
     );
   }
 
@@ -553,7 +553,7 @@ export class SnapKeyring extends EventEmitter {
   } {
     return (
       Array.from(this.#accounts.values()).find(
-        (entry) => entry.account.address === address,
+        ({ account }) => account.address === address,
       ) ?? throwError(`Account '${address}' not found`)
     );
   }
@@ -608,8 +608,7 @@ export class SnapKeyring extends EventEmitter {
    * @returns An array containing all snap keyring accounts.
    */
   async listAccounts(): Promise<InternalAccount[]> {
-    return Array.from(this.#accounts.values()).map((entry) => {
-      const { account, snapId } = entry;
+    return Array.from(this.#accounts.values()).map(({ account, snapId }) => {
       const snap = this.#getSnapMetadata(snapId);
       return {
         ...account,

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -105,7 +105,6 @@ export class SnapKeyring extends EventEmitter {
     message: SnapMessage,
   ): Promise<Json> {
     assert(message, SnapMessageStruct);
-
     switch (message.method) {
       case KeyringEvent.AccountCreated: {
         assert(message, AccountCreatedEventStruct);
@@ -170,7 +169,7 @@ export class SnapKeyring extends EventEmitter {
       case KeyringEvent.RequestApproved: {
         assert(message, RequestApprovedEventStruct);
         const { id, result } = message.params;
-        this.#resolveRequest(id, result);
+        this.#approveRequest(id, result);
         return null;
       }
 
@@ -466,7 +465,7 @@ export class SnapKeyring extends EventEmitter {
    * @param id - ID of the request to resolve.
    * @param result - Result of the request.
    */
-  #resolveRequest(id: string, result: any): void {
+  #approveRequest(id: string, result: any): void {
     const promise = this.#pendingRequests.getOrThrow(id, 'Pending request');
     this.#pendingRequests.delete(id);
     promise.resolve(result);

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -618,7 +618,7 @@ export class SnapKeyring extends EventEmitter {
           keyring: {
             type: this.type,
           },
-          ...(snap && { snap }),
+          ...(snap !== undefined && { snap }),
         },
       };
     });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -211,7 +211,7 @@ export class SnapKeyring extends EventEmitter {
    * @returns The addresses of the accounts in this keyring.
    */
   async getAccounts(): Promise<string[]> {
-    return unique([...this.#addressToAccount.keys()]);
+    return unique(this.#addressToAccount.keys());
   }
 
   /**

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -85,7 +85,7 @@ export class SnapKeyring extends EventEmitter {
         const { account } = params as { account: KeyringAccount };
 
         // TODO: The UI still uses the account address to identify accounts, so
-        // we need to prevent the creation of duplicate accounts for now to
+        // we need to block the creation of duplicate accounts for now to
         // prevent accounts from being overwritten.
         if (await this.#callbacks.addressExists(account.address)) {
           throw new Error(`Account '${account.address}' already exists`);
@@ -194,8 +194,6 @@ export class SnapKeyring extends EventEmitter {
    * @returns The list of account addresses.
    */
   async getAccounts(): Promise<string[]> {
-    // Do not call the snap here. This method is called by the UI, keep it
-    // _fast_.
     return unique([...this.#addressToAccount.keys()]);
   }
 

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -350,8 +350,8 @@ export class SnapKeyring extends EventEmitter {
       }
     })();
 
-    // The snap can respond immediately if the request is not async. In that
-    // case we must delete the promise to prevent a leak.
+    // If the snap answers synchronously, the promise must be removed from the
+    // map to prevent a leak.
     if (!response.pending) {
       this.#pendingRequests.delete(requestId);
       return response.result;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -148,8 +148,8 @@ export class SnapKeyring extends EventEmitter {
       this.#accounts.getOrThrow(newAccount.id, 'Account');
 
     // The address of the account cannot be changed. In the future, we will
-    // support changing the address of an account since it will be required
-    // to support UTXO-based chains.
+    // support changing the address of an account since it will be required to
+    // support UTXO-based chains.
     if (oldAccount.address !== newAccount.address) {
       throw new Error(`Cannot change address of account '${newAccount.id}'`);
     }
@@ -178,11 +178,11 @@ export class SnapKeyring extends EventEmitter {
     assert(message, AccountDeletedEventStruct);
     const { id } = message.params;
 
-    // We can ignore the case where the account was already removed from
-    // the keyring, making the deletion idempotent.
+    // We can ignore the case where the account was already removed from the
+    // keyring, making the deletion idempotent.
     //
-    // This happens when the keyring calls the snap to delete an account,
-    // and the snap responds with an AccountDeleted event.
+    // This happens when the keyring calls the snap to delete an account, and
+    // the snap responds with an AccountDeleted event.
     if (this.#accounts.has(id)) {
       const {
         snapId: expectedSnapId,

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -20,6 +20,16 @@ describe('unique', () => {
     const result = unique(arr);
     expect(result).toStrictEqual([{ name: 'John' }, { name: 'Jane' }]);
   });
+
+  it('returns an array with unique values from a map', () => {
+    const map = new Map<number, string>([
+      [1, 'John'],
+      [2, 'Jane'],
+      [3, 'John'],
+    ]);
+    const result = unique(map.values());
+    expect(result).toStrictEqual(['John', 'Jane']);
+  });
 });
 
 describe('toJson', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,4 +1,10 @@
-import { ensureDefined, throwError, toJson, unique } from './util';
+import {
+  ensureDefined,
+  equalsIgnoreCase,
+  throwError,
+  toJson,
+  unique,
+} from './util';
 
 describe('unique', () => {
   it('returns an empty array when given an empty array', () => {
@@ -66,5 +72,15 @@ describe('ensureDefined', () => {
 describe('throwError', () => {
   it('throws an error with the given message', () => {
     expect(() => throwError('hello')).toThrow('hello');
+  });
+});
+
+describe('equalsIgnoreCase', () => {
+  it('returns true for equal strings', () => {
+    expect(equalsIgnoreCase('hello', 'HELLO')).toBe(true);
+  });
+
+  it('returns false for different strings', () => {
+    expect(equalsIgnoreCase('hello', 'world')).toBe(false);
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -67,3 +67,14 @@ export function ensureDefined<Type>(
 export function throwError(message: string): never {
   throw new Error(message);
 }
+
+/**
+ * Compares two strings for equality, ignoring case.
+ *
+ * @param a - The first string to compare.
+ * @param b - The second string to compare.
+ * @returns `true` if the strings are equal, ignoring case. `false` otherwise.
+ */
+export function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,7 @@ export function strictMask<Type, Schema>(
  * @param array - Array to remove duplicates from.
  * @returns Array with duplicates removed.
  */
-export function unique<Type>(array: Type[]): Type[] {
+export function unique<Type>(array: Type[] | Iterable<Type>): Type[] {
   return [...new Set(array)];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,8 +1064,8 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/keyring-api": ^0.2.5
-    "@metamask/snaps-controllers": ^0.38.2-flask.1
+    "@metamask/keyring-api": ^0.2.6
+    "@metamask/snaps-controllers": ^2.0.0
     "@metamask/utils": ^8.1.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
@@ -1120,19 +1120,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "@metamask/keyring-api@npm:0.2.5"
+"@metamask/keyring-api@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@metamask/keyring-api@npm:0.2.6"
   dependencies:
     "@metamask/providers": ^13.0.0
-    "@metamask/rpc-methods": ^0.38.1-flask.1
-    "@metamask/snaps-controllers": ^0.38.2-flask.1
-    "@metamask/snaps-utils": ^0.38.2-flask.1
+    "@metamask/rpc-methods": ^2.0.0
+    "@metamask/snaps-controllers": ^2.0.0
+    "@metamask/snaps-utils": ^2.0.0
     "@metamask/utils": ^8.1.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: ca567388f5963f7c6adaf9d7bfdfa783f5869ab85d906181cc32d2c3c1328af78c15eea661522d1c5dfb7b23b7dd3c6a9917b4c9eae794d187e03483ba42cd3e
+  checksum: 68a1181b72bc07d2fc41806f6526f6b9cdae53ff976cf4038f00d6d07de94e3dbef7e03c6533e30f84e1025baa7d5503f18b83f3bc6a0f8e3452b8037fc97d96
   languageName: node
   linkType: hard
 
@@ -1167,13 +1167,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/post-message-stream@npm:^6.1.2":
-  version: 6.2.0
-  resolution: "@metamask/post-message-stream@npm:6.2.0"
+"@metamask/post-message-stream@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@metamask/post-message-stream@npm:7.0.0"
   dependencies:
     "@metamask/utils": ^5.0.0
-    readable-stream: 2.3.3
-  checksum: 657cdb2dd61a46a4da7f036a97ef0aa9ad8e918d8f8c0fd620eaede4a32c2ff909738a7dfb2b1e6099e7771fd03c3466b60fedab56e39a5cc5507927758e3cb7
+    readable-stream: 3.6.2
+  checksum: a922874f00870e0c666216e592dff6c508e926fae122646d2792c9a7fac4f73323c65046a1eb9dc48a4b0e7de3bbcf753f5ad470688ed4ba2298b4d3a9b39c7d
   languageName: node
   linkType: hard
 
@@ -1225,20 +1225,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/rpc-methods@npm:^0.38.1-flask.1":
-  version: 0.38.1-flask.1
-  resolution: "@metamask/rpc-methods@npm:0.38.1-flask.1"
+"@metamask/rpc-methods@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/rpc-methods@npm:2.0.0"
   dependencies:
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^4.1.0
-    "@metamask/snaps-ui": ^0.37.4-flask.1
-    "@metamask/snaps-utils": ^0.38.2-flask.1
+    "@metamask/snaps-ui": ^2.0.0
+    "@metamask/snaps-utils": ^2.0.0
     "@metamask/types": ^1.1.0
-    "@metamask/utils": ^6.0.1
+    "@metamask/utils": ^8.1.0
     "@noble/hashes": ^1.3.1
     eth-rpc-errors: ^4.0.3
     superstruct: ^1.0.3
-  checksum: 49700a41a1340d36d484086a4f6ca0a3fea27f5f8119c9a9af9c2cd0aeecf7f603f6c89a2f122232c66a238e281023df82d4ad38c799da5a137ccfcf0bca6857
+  checksum: 0753e0c32cc52c930716506c417c4b64a34fb54429f2dfaa70fd1bb00b5dae6e9452ef85f4b23d989f01dafc27ce43e1f89f6a22778ecc313f93aaf57cde3038
   languageName: node
   linkType: hard
 
@@ -1266,20 +1266,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^0.38.2-flask.1":
-  version: 0.38.2-flask.1
-  resolution: "@metamask/snaps-controllers@npm:0.38.2-flask.1"
+"@metamask/snaps-controllers@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snaps-controllers@npm:2.0.0"
   dependencies:
     "@metamask/approval-controller": ^3.5.0
     "@metamask/base-controller": ^3.2.0
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/permission-controller": ^4.1.0
-    "@metamask/post-message-stream": ^6.1.2
-    "@metamask/rpc-methods": ^0.38.1-flask.1
-    "@metamask/snaps-execution-environments": ^0.38.2-flask.1
-    "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-utils": ^0.38.2-flask.1
-    "@metamask/utils": ^6.0.1
+    "@metamask/post-message-stream": ^7.0.0
+    "@metamask/rpc-methods": ^2.0.0
+    "@metamask/snaps-execution-environments": ^2.0.0
+    "@metamask/snaps-registry": ^2.0.0
+    "@metamask/snaps-utils": ^2.0.0
+    "@metamask/utils": ^8.1.0
     "@xstate/fsm": ^2.0.0
     concat-stream: ^2.0.0
     eth-rpc-errors: ^4.0.3
@@ -1288,65 +1288,63 @@ __metadata:
     json-rpc-engine: ^6.1.0
     json-rpc-middleware-stream: ^4.2.0
     nanoid: ^3.1.31
-    pump: ^3.0.0
     readable-web-to-node-stream: ^3.0.2
     tar-stream: ^2.2.0
-  checksum: 738044e70b079fd62195219aa68260b4afae4855826b8d7b94f53edad69d8befaf77c67c2a9dbf2363457223b0560652578eeea438150d37a56a4adcd89e6e43
+  checksum: 91eb34c3ffedfeb4298a6e28cf1c5548f42559d982570ac754bfadcf1ff98db9909e244617eaf0b6773a9464ccfbf6588c68dc01b2f112bf4ead64fd0801f72a
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^0.38.2-flask.1":
-  version: 0.38.2-flask.1
-  resolution: "@metamask/snaps-execution-environments@npm:0.38.2-flask.1"
+"@metamask/snaps-execution-environments@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snaps-execution-environments@npm:2.0.0"
   dependencies:
     "@metamask/object-multiplex": ^1.2.0
-    "@metamask/post-message-stream": ^6.1.2
+    "@metamask/post-message-stream": ^7.0.0
     "@metamask/providers": ^11.1.1
-    "@metamask/rpc-methods": ^0.38.1-flask.1
-    "@metamask/snaps-utils": ^0.38.2-flask.1
-    "@metamask/utils": ^6.0.1
+    "@metamask/rpc-methods": ^2.0.0
+    "@metamask/snaps-utils": ^2.0.0
+    "@metamask/utils": ^8.1.0
     eth-rpc-errors: ^4.0.3
     json-rpc-engine: ^6.1.0
     nanoid: ^3.1.31
-    pump: ^3.0.0
     superstruct: ^1.0.3
-  checksum: 68c1adcb8fe227c989c02ea5f7820f0d58b0e9442b21d0043e2f06a7ea3a6607a5e0bdde82aceecc12e265b27bd1e5a719fb4ec901f19adea3a37d5412ca8415
+  checksum: bd744aa39b20430c8ef69532ba026213b8f81ffaf64a092a77e76561f653a3ebeab2c2c1b1ee069798c44e4e17203a6816810f558cea7a44d94499ad198dbade
   languageName: node
   linkType: hard
 
-"@metamask/snaps-registry@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "@metamask/snaps-registry@npm:1.2.2"
+"@metamask/snaps-registry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snaps-registry@npm:2.0.0"
   dependencies:
-    "@metamask/utils": ^7.1.0
+    "@metamask/utils": ^8.1.0
     "@noble/secp256k1": ^1.7.1
     superstruct: ^1.0.3
-  checksum: 02289b349390466158c4842c6398b56c0a6352258657eb186331636774a894782607aa0c4e4c772689c89248856c325d914a0d8c8f4b739e9324d60b0fb92da1
+  checksum: 621baf98c53c490d4bf8bf784910943e3c147cc2abdbcf5ea56ae6fcd45a1a412da79b0ef778b8f9d8c46b9272068d3dd5909be6691579590d2632c6baee8992
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:^0.37.4-flask.1":
-  version: 0.37.4-flask.1
-  resolution: "@metamask/snaps-ui@npm:0.37.4-flask.1"
+"@metamask/snaps-ui@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snaps-ui@npm:2.0.0"
   dependencies:
-    "@metamask/utils": ^6.0.1
+    "@metamask/utils": ^8.1.0
     superstruct: ^1.0.3
-  checksum: d4e0a3c5f82a6edbf7bc82280fab364b93787e7d9995854208dd4200e188f37691216928967a5b75e6be5ebfeb360e638af39ac0043f1bdddb0c2ff7a5cdbce5
+  checksum: 0a8886402aea3aeebc18dd8058f169b7c751f93aac22286a693dbb6f787b10e44f7da9efa40981dde427f2301ce3da11af93e37398157eb75fdce85c53f48dd8
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^0.38.2-flask.1":
-  version: 0.38.2-flask.1
-  resolution: "@metamask/snaps-utils@npm:0.38.2-flask.1"
+"@metamask/snaps-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snaps-utils@npm:2.0.0"
   dependencies:
     "@babel/core": ^7.20.12
     "@babel/types": ^7.18.7
     "@metamask/base-controller": ^3.2.0
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^4.1.0
-    "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": ^0.37.4-flask.1
-    "@metamask/utils": ^6.0.1
+    "@metamask/snaps-registry": ^2.0.0
+    "@metamask/snaps-ui": ^2.0.0
+    "@metamask/utils": ^8.1.0
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
     chalk: ^4.1.2
@@ -1360,7 +1358,7 @@ __metadata:
     ses: ^0.18.7
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
-  checksum: cb95a67a1267299aacb5b85b25a35dbfd14f68060198974cc1a26b9a2e7eff5acd13700b9100e3546dfc7e78ed937b06aecb5c4884c32ff77b2d28c77e7f97b6
+  checksum: d7cc6c7398f80d10824dcf429246fa7fb729accddad613703fa1cd46ac490e6afe7febf0183ddcddfa995fe9779df5386baa51e5cb7ca9a2a6c33b40293932ee
   languageName: node
   linkType: hard
 
@@ -1395,20 +1393,6 @@ __metadata:
     semver: ^7.3.8
     superstruct: ^1.0.3
   checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "@metamask/utils@npm:7.1.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@noble/hashes": ^1.3.1
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.5.4
-    superstruct: ^1.0.3
-  checksum: 165ed378f4ac5ca42c241d32154e15b609f9e772a9dc069b870613c005dc0e7e4fa92204c30e98ec2317f1e38c77747057671a26fd0a5ba36a288e3c9ef03790
   languageName: node
   linkType: hard
 
@@ -6414,13 +6398,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-nextick-args@npm:~1.0.6":
-  version: 1.0.7
-  resolution: "process-nextick-args@npm:1.0.7"
-  checksum: 41224fbc803ac6c96907461d4dfc20942efa3ca75f2d521bcf7cf0e89f8dec127fb3fb5d76746b8fb468a232ea02d84824fae08e027aec185fd29049c66d49f8
-  languageName: node
-  linkType: hard
-
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -6550,18 +6527,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:2.3.3":
-  version: 2.3.3
-  resolution: "readable-stream@npm:2.3.3"
+"readable-stream@npm:3.6.2, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~1.0.6
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.0.3
-    util-deprecate: ~1.0.1
-  checksum: 76f9863065d7edc14abd78e68784048487e83a4b6908336ba3eacb5e9544d642ad60836f91fab16e1dc6ad9e493dfe6c2e5b65f370ec65454d415efa50361a76
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
   languageName: node
   linkType: hard
 
@@ -6577,17 +6550,6 @@ __metadata:
     string_decoder: ~1.1.1
     util-deprecate: ~1.0.1
   checksum: 65645467038704f0c8aaf026a72fbb588a9e2ef7a75cd57a01702ee9db1c4a1e4b03aaad36861a6a0926546a74d174149c8c207527963e0c2d3eee2f37678a42
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
   languageName: node
   linkType: hard
 
@@ -7164,15 +7126,6 @@ __metadata:
   dependencies:
     safe-buffer: ~5.2.0
   checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
-  languageName: node
-  linkType: hard
-
-"string_decoder@npm:~1.0.3":
-  version: 1.0.3
-  resolution: "string_decoder@npm:1.0.3"
-  dependencies:
-    safe-buffer: ~5.1.0
-  checksum: 57ef02a148fd1ff2f20fe1accd944505ed3703e78bb28d302d940b2ad3dfb469508f79dcd0275ba1960d9675aa206452f76b2416059a6d0b0200bd7e9f552cdb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/keyring-api": ^0.2.6
+    "@metamask/keyring-api": "github:MetaMask/keyring-api#37c0e66548194607ed0715ce0f1abe9665ff3adc"
     "@metamask/snaps-controllers": ^2.0.0
     "@metamask/utils": ^8.1.0
     "@types/jest": ^28.1.6
@@ -1120,9 +1120,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^0.2.6":
+"@metamask/keyring-api@github:MetaMask/keyring-api#37c0e66548194607ed0715ce0f1abe9665ff3adc":
   version: 0.2.6
-  resolution: "@metamask/keyring-api@npm:0.2.6"
+  resolution: "@metamask/keyring-api@https://github.com/MetaMask/keyring-api.git#commit=37c0e66548194607ed0715ce0f1abe9665ff3adc"
   dependencies:
     "@metamask/providers": ^13.0.0
     "@metamask/rpc-methods": ^2.0.0
@@ -1132,7 +1132,7 @@ __metadata:
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: 68a1181b72bc07d2fc41806f6526f6b9cdae53ff976cf4038f00d6d07de94e3dbef7e03c6533e30f84e1025baa7d5503f18b83f3bc6a0f8e3452b8037fc97d96
+  checksum: 2728047361c62989272aefd9b9eabca6c980c553fe19e617cc7d5da0237fce51f0e68d005d66d5f32b621dc3d03490ddb773e64f5b082d66dffe7a972e28a5ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a new callback method that checks if the account already exists on MetaMas to prevent a snap from adding a duplicate account.

https://github.com/MetaMask/eth-snap-keyring/assets/68558152/76f5687b-39d3-4793-9e12-9f4c82f1bd0b

