### PR TITLE
feat: add method to remove all accounts given a snap ID

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -717,4 +717,12 @@ describe('SnapKeyring', () => {
       expect(result).toStrictEqual(expected);
     });
   });
+
+  describe('removeAccountsBySnapId', () => {
+    it('removes all accounts owned by a snap', async () => {
+      mockSnapController.handleRequest.mockResolvedValue(null);
+      await keyring.removeAccountsBySnapId(snapId);
+      expect(await keyring.getAccounts()).toStrictEqual([]);
+    });
+  });
 });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -600,6 +600,20 @@ export class SnapKeyring extends EventEmitter {
   }
 
   /**
+   * Remove all accounts associated with a given Snap ID.
+   *
+   * @param snapId - The Snap ID to remove accounts for.
+   * @returns A Promise that resolves when all accounts have been removed.
+   */
+  async removeAccountsBySnapId(snapId: string): Promise<void> {
+    for (const entry of this.#accounts.values()) {
+      if (entry.snapId === snapId) {
+        await this.removeAccount(entry.account.address.toLowerCase());
+      }
+    }
+  }
+
+  /**
    * List all snap keyring accounts.
    *
    * @returns An array containing all snap keyring accounts.


### PR DESCRIPTION
The `removeAccountsBySnapId` method will be used by the UI to remove all accounts related to a snap.