### PR TITLE
fix: remove the `removeAccountsBySnapId` method

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -757,12 +757,4 @@ describe('SnapKeyring', () => {
       expect(result).toStrictEqual(expected);
     });
   });
-
-  describe('removeAccountsBySnapId', () => {
-    it('removes all accounts owned by a snap', async () => {
-      mockSnapController.handleRequest.mockResolvedValue(null);
-      await keyring.removeAccountsBySnapId(snapId);
-      expect(await keyring.getAccounts()).toStrictEqual([]);
-    });
-  });
 });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -625,20 +625,6 @@ export class SnapKeyring extends EventEmitter {
   }
 
   /**
-   * Remove all accounts associated with a given Snap ID.
-   *
-   * @param snapId - The Snap ID to remove accounts for.
-   * @returns A Promise that resolves when all accounts have been removed.
-   */
-  async removeAccountsBySnapId(snapId: string): Promise<void> {
-    for (const entry of this.#accounts.values()) {
-      if (entry.snapId === snapId) {
-        await this.removeAccount(entry.account.address.toLowerCase());
-      }
-    }
-  }
-
-  /**
    * List all snap keyring accounts.
    *
    * @returns An array containing all snap keyring accounts.


### PR DESCRIPTION
Accounts shouldn't be removed by directly calling the keyring because they also need to be removed from other controllers, which is done by the `removeAccount` method from `metamask-controller.js`.