### PR TITLE
feat: add the `getAccountsBySnapId` method

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -757,4 +757,13 @@ describe('SnapKeyring', () => {
       expect(result).toStrictEqual(expected);
     });
   });
+
+  describe('getAccountsBySnapId', () => {
+    it('returns the list of addresses of a snap', async () => {
+      const addresses = await keyring.getAccountsBySnapId(snapId);
+      expect(addresses).toStrictEqual(
+        accounts.map((a) => a.address.toLowerCase()),
+      );
+    });
+  });
 });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -377,6 +377,20 @@ export class SnapKeyring extends EventEmitter {
   }
 
   /**
+   * Get the addresses of the accounts associated with a given Snap.
+   *
+   * @param snapId - Snap ID to filter by.
+   * @returns The addresses of the accounts associated with the given Snap.
+   */
+  async getAccountsBySnapId(snapId: string): Promise<string[]> {
+    return unique(
+      [...this.#accounts.values()]
+        .filter(({ snapId: accountSnapId }) => accountSnapId === snapId)
+        .map(({ account }) => account.address.toLowerCase()),
+    );
+  }
+
+  /**
    * Submit a request to a snap.
    *
    * @param opts - Request options.


### PR DESCRIPTION
This method will be used by the UI to get the addresses of the accounts to be removed.