### PR TITLE
feat: add `getAccountByAddress` method

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -768,7 +768,7 @@ describe('SnapKeyring', () => {
   });
 
   describe('getAccountByAddress', () => {
-    it('returns the account', async () => {
+    it('returns the account with that address', async () => {
       const snapMetadata = {
         manifest: {
           proposedName: 'snap-name',

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -766,4 +766,27 @@ describe('SnapKeyring', () => {
       );
     });
   });
+
+  describe('getAccountByAddress', () => {
+    it('returns the account', async () => {
+      const snapMetadata = {
+        manifest: {
+          proposedName: 'snap-name',
+        },
+        id: snapId,
+        enabled: true,
+      };
+      mockSnapController.get.mockReturnValue(snapMetadata);
+      expect(
+        await keyring.getAccountByAddress(accounts[0].address),
+      ).toStrictEqual({
+        ...accounts[0],
+        metadata: {
+          name: '',
+          snap: { id: snapId, name: 'snap-name', enabled: true },
+          keyring: { type: 'Snap Keyring' },
+        },
+      });
+    });
+  });
 });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -639,6 +639,21 @@ export class SnapKeyring extends EventEmitter {
   }
 
   /**
+   * Return an internal account object for a given address.
+   *
+   * @param address - Address of the account to return.
+   * @returns An internal account object for the given address.
+   */
+  async getAccountByAddress(
+    address: string,
+  ): Promise<InternalAccount | undefined> {
+    const accounts = await this.listAccounts();
+    return accounts.find(({ address: accountAddress }) =>
+      equalsIgnoreCase(accountAddress, address),
+    );
+  }
+
+  /**
    * List all snap keyring accounts.
    *
    * @returns An array containing all snap keyring accounts.


### PR DESCRIPTION
This method should be removed in the future once we have the Accounts Controller, but for now we have to rely on exposing this method to allow other components to get the Snap metadata associated with an account.