### PR TITLE
feat: add `redirectUser` callback

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -279,7 +279,6 @@ describe('SnapKeyring', () => {
         snapId,
         url,
         message,
-        expect.any(String), // if you don’t know `method` value in test context
       );
       spy.mockRestore();
     });

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -72,12 +72,7 @@ export type SnapKeyringCallbacks = {
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
-  redirectUser(
-    snapId: string,
-    url: string,
-    message: string,
-    method: string,
-  ): Promise<void>;
+  redirectUser(snapId: string, url: string, message: string): Promise<void>;
 };
 
 /**
@@ -453,7 +448,7 @@ export class SnapKeyring extends EventEmitter {
     // If the snap answers asynchronously, we will inform the user with a redirect
     if (response.redirect?.message || response.redirect?.url) {
       const { message = '', url = '' } = response.redirect;
-      await this.#callbacks.redirectUser(snapId, url, message, method);
+      await this.#callbacks.redirectUser(snapId, url, message);
     }
 
     return promise.promise;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -72,7 +72,12 @@ export type SnapKeyringCallbacks = {
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
-  redirectUser(message: string, url: string, method: string): Promise<void>;
+  redirectUser(
+    snapId: string,
+    url: string,
+    message: string,
+    method: string,
+  ): Promise<void>;
 };
 
 /**
@@ -450,7 +455,7 @@ export class SnapKeyring extends EventEmitter {
     if (response.redirect?.message || response.redirect?.url) {
       const { message, url } = response.redirect;
       if (message && url) {
-        await this.#callbacks.redirectUser(message, url, method);
+        await this.#callbacks.redirectUser(snapId, url, message, method);
       } else {
         console.warn(
           `Snap '${snapId}' requested a redirect but the message or URL is missing.`,

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -453,14 +453,8 @@ export class SnapKeyring extends EventEmitter {
     // In the future, this should be handled by the UI. For now, we just log
     // the redirect information for debugging purposes.
     if (response.redirect?.message || response.redirect?.url) {
-      const { message, url } = response.redirect;
-      if (message && url) {
-        await this.#callbacks.redirectUser(snapId, url, message, method);
-      } else {
-        console.warn(
-          `Snap '${snapId}' requested a redirect but the message or URL is missing.`,
-        );
-      }
+      const { message = '', url = '' } = response.redirect;
+      await this.#callbacks.redirectUser(snapId, url, message, method);
     }
 
     return promise.promise;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -72,6 +72,7 @@ export type SnapKeyringCallbacks = {
     snapId: string,
     handleUserInput: (accepted: boolean) => Promise<void>,
   ): Promise<void>;
+  redirectUser(message: string, url: string, method: string): Promise<void>;
 };
 
 /**
@@ -447,10 +448,14 @@ export class SnapKeyring extends EventEmitter {
     // In the future, this should be handled by the UI. For now, we just log
     // the redirect information for debugging purposes.
     if (response.redirect?.message || response.redirect?.url) {
-      const { message = '', url = '' } = response.redirect;
-      console.log(
-        `The snap requested a redirect: message="${message}", url="${url}"`,
-      );
+      const { message, url } = response.redirect;
+      if (message && url) {
+        await this.#callbacks.redirectUser(message, url, method);
+      } else {
+        console.warn(
+          `Snap '${snapId}' requested a redirect but the message or URL is missing.`,
+        );
+      }
     }
 
     return promise.promise;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -450,8 +450,7 @@ export class SnapKeyring extends EventEmitter {
       return response.result;
     }
 
-    // In the future, this should be handled by the UI. For now, we just log
-    // the redirect information for debugging purposes.
+    // If the snap answers asynchronously, we will inform the user with a redirect
     if (response.redirect?.message || response.redirect?.url) {
       const { message = '', url = '' } = response.redirect;
       await this.#callbacks.redirectUser(snapId, url, message, method);


### PR DESCRIPTION
## What
This PR enables this issue: https://github.com/MetaMask/accounts-planning/issues/35

This callback will be implemented in [this extension PR](https://github.com/MetaMask/metamask-extension/pull/21218). 

For async transactions, we call this callback which will trigger a confirmation modal in the extension with the URL and the message as part of the UI. This will be used to instruct users to complete signings at the specified URL or app. 

## How
- add a `redirectUser` callback with the following structure
```ts
  redirectUser(
    snapId: string,
    url: string,
    message: string,
    method: string,
  ): Promise<void>;
```
- inside `submitRequest`, add the following block 
```ts
    if (response.redirect?.message || response.redirect?.url) {
      const { message = '', url = '' } = response.redirect;
      await this.#callbacks.redirectUser(snapId, url, message, method);
    }
```
- In our case, these fields will be populated in the [snap-simple-keyring dapp](https://metamask.github.io/snap-simple-keyring/latest/). I am currently in the process of making these changes [here](https://github.com/MetaMask/snap-simple-keyring/pull/98)