### PR TITLE
fix: remove `async` from `listAccounts` and `getAccountByAddress`

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -116,7 +116,7 @@ describe('SnapKeyring', () => {
         }),
       ).toBeNull();
 
-      const keyringAccounts = await keyring.listAccounts();
+      const keyringAccounts = keyring.listAccounts();
       expect(keyringAccounts.length).toBeGreaterThan(0);
       expect(keyringAccounts[0]?.methods).toStrictEqual([]);
     });
@@ -749,7 +749,7 @@ describe('SnapKeyring', () => {
         enabled: true,
       };
       mockSnapController.get.mockReturnValue(snapObject);
-      const result = await keyring.listAccounts();
+      const result = keyring.listAccounts();
       const expected = accounts.map((a) => ({
         ...a,
         metadata: {
@@ -783,9 +783,7 @@ describe('SnapKeyring', () => {
         enabled: true,
       };
       mockSnapController.get.mockReturnValue(snapMetadata);
-      expect(
-        await keyring.getAccountByAddress(accounts[0].address),
-      ).toStrictEqual({
+      expect(keyring.getAccountByAddress(accounts[0].address)).toStrictEqual({
         ...accounts[0],
         metadata: {
           name: '',

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -642,10 +642,8 @@ export class SnapKeyring extends EventEmitter {
    * @param address - Address of the account to return.
    * @returns An internal account object for the given address.
    */
-  async getAccountByAddress(
-    address: string,
-  ): Promise<InternalAccount | undefined> {
-    const accounts = await this.listAccounts();
+  getAccountByAddress(address: string): InternalAccount | undefined {
+    const accounts = this.listAccounts();
     return accounts.find(({ address: accountAddress }) =>
       equalsIgnoreCase(accountAddress, address),
     );
@@ -656,7 +654,7 @@ export class SnapKeyring extends EventEmitter {
    *
    * @returns An array containing all snap keyring accounts.
    */
-  async listAccounts(): Promise<InternalAccount[]> {
+  listAccounts(): InternalAccount[] {
     return [...this.#accounts.values()].map(({ account, snapId }) => {
       const snap = this.#getSnapMetadata(snapId);
       return {


### PR DESCRIPTION
This Pr removes the async prefix for the functions `listAccounts` and `getAccountByAddress`. 
