### PR TITLE
feat: use a `snapId`-indexed map

### DIFF
--- a/src/SnapIdMap.test.ts
+++ b/src/SnapIdMap.test.ts
@@ -1,0 +1,246 @@
+import { InvalidSnapIdError, SnapIdMap } from './SnapIdMap';
+
+describe('SnapIdMap', () => {
+  describe('toObject', () => {
+    it('returns an empty object when the map is empty', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      const obj = map.toObject();
+      expect(obj).toStrictEqual({});
+    });
+
+    it('returns an object with the same keys and values as the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      map.set('bar', { snapId: 'snap-2', value: 2 });
+      const obj = map.toObject();
+      expect(obj).toStrictEqual({
+        foo: { snapId: 'snap-1', value: 1 },
+        bar: { snapId: 'snap-2', value: 2 },
+      });
+    });
+
+    it('returns an object with lowercase keys', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      map.set('BAR', { snapId: 'snap-2', value: 2 });
+      const obj = map.toObject();
+      expect(obj).toStrictEqual({
+        foo: { snapId: 'snap-1', value: 1 },
+        bar: { snapId: 'snap-2', value: 2 },
+      });
+    });
+  });
+
+  describe('fromObject', () => {
+    it('returns an empty map when the object is empty', () => {
+      const map = SnapIdMap.fromObject({});
+      expect(map.size).toBe(0);
+    });
+
+    it('returns a map with the same keys and values as the object', () => {
+      const map = SnapIdMap.fromObject({
+        foo: { snapId: 'snap-1', value: 1 },
+        bar: { snapId: 'snap-2', value: 2 },
+      });
+      expect(map.size).toBe(2);
+      expect(map.get('snap-1', 'foo')).toStrictEqual({
+        snapId: 'snap-1',
+        value: 1,
+      });
+      expect(map.get('snap-2', 'bar')).toStrictEqual({
+        snapId: 'snap-2',
+        value: 2,
+      });
+    });
+
+    it('converts keys to lowercase', () => {
+      const map = SnapIdMap.fromObject({
+        FOO: { snapId: 'snap-1', value: 1 },
+        BAR: { snapId: 'snap-2', value: 2 },
+      });
+      expect(map.size).toBe(2);
+      expect(map.get('snap-1', 'foo')).toStrictEqual({
+        snapId: 'snap-1',
+        value: 1,
+      });
+      expect(map.get('snap-2', 'bar')).toStrictEqual({
+        snapId: 'snap-2',
+        value: 2,
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('returns undefined when the key is not in the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      const value = map.get('snap-1', 'foo');
+      expect(value).toBeUndefined();
+    });
+
+    it('returns undefined when the snapId does not match', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const value = map.get('snap-2', 'foo');
+      expect(value).toBeUndefined();
+    });
+
+    it('returns the value when the snapId matches', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const value = map.get('snap-1', 'foo');
+      expect(value).toStrictEqual({ snapId: 'snap-1', value: 1 });
+    });
+  });
+
+  describe('has', () => {
+    it('returns false when the key is not in the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      const hasKey = map.has('snap-1', 'foo');
+      expect(hasKey).toBe(false);
+    });
+
+    it('returns false when the snapId does not match', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const hasKey = map.has('snap-2', 'foo');
+      expect(hasKey).toBe(false);
+    });
+
+    it('returns true when the snapId matches', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const hasKey = map.has('snap-1', 'foo');
+      expect(hasKey).toBe(true);
+    });
+  });
+
+  describe('delete', () => {
+    it('returns false when the key is not in the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      const deleted = map.delete('snap-1', 'foo');
+      expect(deleted).toBe(false);
+    });
+
+    it('returns false when the snapId does not match', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const deleted = map.delete('snap-2', 'foo');
+      expect(deleted).toBe(false);
+    });
+
+    it('deletes the key when the snapId matches', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const deleted = map.delete('snap-1', 'foo');
+      expect(deleted).toBe(true);
+      expect(map.has('snap-1', 'foo')).toBe(false);
+    });
+  });
+
+  describe('set', () => {
+    it('adds a new key-value pair to the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      expect(map.size).toBe(1);
+      expect(map.get('snap-1', 'foo')).toStrictEqual({
+        snapId: 'snap-1',
+        value: 1,
+      });
+    });
+
+    it('updates the value of an existing key', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      map.set('foo', { snapId: 'snap-1', value: 2 });
+      expect(map.size).toBe(1);
+      expect(map.get('snap-1', 'foo')).toStrictEqual({
+        snapId: 'snap-1',
+        value: 2,
+      });
+    });
+
+    it('throws an error if the key is already in the map with a different snapId', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      expect(() => {
+        map.set('foo', { snapId: 'snap-2', value: 2 });
+      }).toThrow(InvalidSnapIdError);
+    });
+  });
+
+  describe('values', () => {
+    it('returns an empty iterator when the map is empty', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      const iterator = map.values();
+      expect(iterator.next().done).toBe(true);
+    });
+
+    it('returns an iterator with all the values in the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      map.set('bar', { snapId: 'snap-2', value: 2 });
+      const iterator = map.values();
+      expect(iterator.next().value).toStrictEqual({
+        snapId: 'snap-1',
+        value: 1,
+      });
+      expect(iterator.next().value).toStrictEqual({
+        snapId: 'snap-2',
+        value: 2,
+      });
+      expect(iterator.next().done).toBe(true);
+    });
+
+    it('returns an iterator that reflects changes to the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      const iterator = map.values();
+      expect(iterator.next().value).toStrictEqual({
+        snapId: 'snap-1',
+        value: 1,
+      });
+      map.set('bar', { snapId: 'snap-2', value: 2 });
+      expect(iterator.next().value).toStrictEqual({
+        snapId: 'snap-2',
+        value: 2,
+      });
+      expect(iterator.next().done).toBe(true);
+    });
+  });
+
+  describe('size', () => {
+    it('returns 0 when the map is empty', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      expect(map.size).toBe(0);
+    });
+
+    it('returns the number of key-value pairs in the map', () => {
+      const map = new SnapIdMap<{ snapId: string; value: number }>();
+      map.set('foo', { snapId: 'snap-1', value: 1 });
+      map.set('bar', { snapId: 'snap-2', value: 2 });
+      expect(map.size).toBe(2);
+    });
+  });
+});
+
+describe('InvalidSnapIdError', () => {
+  it('has the correct name', () => {
+    const error = new InvalidSnapIdError('snap-1', 'foo');
+    expect(error.name).toBe('InvalidSnapIdError');
+  });
+
+  it('has the correct message', () => {
+    const error = new InvalidSnapIdError('snap-1', 'foo');
+    expect(error.message).toBe('Snap "snap-1" is not allowed to set "foo"');
+  });
+
+  it('has the correct snapId property', () => {
+    const error = new InvalidSnapIdError('snap-1', 'foo');
+    expect(error.snapId).toBe('snap-1');
+  });
+
+  it('has the correct key property', () => {
+    const error = new InvalidSnapIdError('snap-1', 'foo');
+    expect(error.key).toBe('foo');
+  });
+});

--- a/src/SnapIdMap.ts
+++ b/src/SnapIdMap.ts
@@ -1,0 +1,246 @@
+import { CaseInsensitiveMap } from './CaseInsensitiveMap';
+
+/**
+ * Error thrown when an invalid Snap ID is encountered.
+ */
+export class InvalidSnapIdError extends Error {
+  /**
+   * The ID of the Snap that caused the error.
+   */
+  snapId: string;
+
+  /**
+   * The key of the element that caused the error.
+   */
+  key: string;
+
+  /**
+   * Creates an instance of `InvalidSnapIdError`.
+   *
+   * @param snapId - The invalid Snap ID.
+   * @param key - The key associated with the invalid Snap ID.
+   */
+  constructor(snapId: string, key: string) {
+    super(`Snap "${snapId}" is not allowed to set "${key}"`);
+    this.name = 'InvalidSnapIdError';
+    this.snapId = snapId;
+    this.key = key;
+  }
+}
+
+/**
+ * A map that associates a string key with a value that has a `snapId`
+ * property. Note that the key is case-insensitive.
+ *
+ * The `snapId` property is used to ensure that only the Snap that added an
+ * item to the map can modify or delete it.
+ */
+export class SnapIdMap<Value extends { snapId: string }> {
+  #map: CaseInsensitiveMap<Value>;
+
+  /**
+   * Creates a new `SnapIdMap` object.
+   *
+   * Example:
+   *
+   * ```ts
+   * const items = [
+   *   ['foo', { snapId: '1', name: 'foo' }],
+   *   ['bar', { snapId: '1', name: 'bar' }],
+   * ];
+   * const map = new SnapIdMap(items);
+   * ```
+   *
+   * @param iterable - An iterable object whose elements are key-value pairs.
+   * Each key-value pair will be added to the new map.
+   */
+  constructor(iterable?: Iterable<readonly [string, Value]>) {
+    this.#map = new CaseInsensitiveMap(iterable);
+  }
+
+  /**
+   * Returns a plain object with the same key-value pairs as this map.
+   *
+   * Example:
+   *
+   * ```ts
+   * const items = [
+   *   ['foo', { snapId: '1', name: 'foo' }],
+   *   ['bar', { snapId: '1', name: 'bar' }],
+   * ];
+   * const map = new SnapIdMap(items);
+   * map.toObject();
+   * // Returns
+   * // {
+   * //   foo: { snapId: '1', name: 'foo' },
+   * //   bar: { snapId: '1', name: 'bar' },
+   * // }
+   * ```
+   *
+   * @returns A plain object with the same key-value pairs as this map.
+   */
+  toObject(): Record<string, Value> {
+    return this.#map.toObject();
+  }
+
+  /**
+   * Returns a new `SnapIdMap` object from an plain object.
+   *
+   * Example:
+   *
+   * ```ts
+   * const obj = {
+   *   foo: { snapId: '1', name: 'foo' },
+   *   bar: { snapId: '1', name: 'bar' },
+   * };
+   * const map = SnapIdMap.fromObject(obj);
+   * ```
+   *
+   * @param obj - A plain object whose elements will be added to the new map.
+   * @returns A new `SnapIdMap` containing the elements of the given object.
+   */
+  static fromObject<Value extends { snapId: string }>(
+    obj: Record<string, Value>,
+  ): SnapIdMap<Value> {
+    return new SnapIdMap(Object.entries(obj));
+  }
+
+  /**
+   * Gets a value from the map.
+   *
+   * If the given key is not present in the map or the Snap ID of the value is
+   * different from the given Snap ID, returns `undefined`.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap();
+   * map.set('foo', { snapId: '1', name: 'foo' });
+   * map.get('1', 'foo'); // Returns { snapId: '1', name: 'foo' }
+   * map.get('2', 'foo'); // Returns `undefined`
+   * map.get('1', 'bar'); // Returns `undefined`
+   * ```
+   *
+   * @param snapId - Snap ID present in the value to get.
+   * @param key - Key of the element to get.
+   * @returns The value associated with the given key and Snap ID.
+   */
+  get(snapId: string, key: string): Value | undefined {
+    const value = this.#map.get(key);
+    return value?.snapId === snapId ? value : undefined;
+  }
+
+  /**
+   * Checks if a key is present in the map.
+   *
+   * If the given key is not present in the map or the Snap ID of the value is
+   * different from the given Snap ID, returns `false`.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap();
+   * map.set('foo', { snapId: '1', name: 'foo' });
+   * map.has('1', 'foo'); // Returns `true`
+   * map.has('2', 'foo'); // Returns `false`
+   * map.has('1', 'bar'); // Returns `false`
+   * ```
+   *
+   * @param snapId - Snap ID present in the value to check.
+   * @param key - Key of the element to check.
+   * @returns `true` if the key is present in the map and the Snap ID of the
+   * value is equal to the given Snap ID, `false` otherwise.
+   */
+  has(snapId: string, key: string): boolean {
+    return this.get(snapId, key) !== undefined;
+  }
+
+  /**
+   * Deletes a key from the map.
+   *
+   * If the given key is not present in the map or the Snap IDs don't match,
+   * returns `false` and does nothing.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap();
+   * map.set('foo', { snapId: '1', name: 'foo' });
+   * map.delete('2', 'foo'); // Returns `false`
+   * map.delete('1', 'bar'); // Returns `false`
+   * map.delete('1', 'foo'); // Returns `true`
+   * ```
+   *
+   * @param snapId - Snap ID present in the value to delete.
+   * @param key - Key of the element to delete.
+   * @returns `true` if the key was present in the map and the Snap ID of the
+   * value was equal to the given Snap ID, `false` otherwise.
+   */
+  delete(snapId: string, key: string): boolean {
+    return this.has(snapId, key) && this.#map.delete(key);
+  }
+
+  /* eslint-disable jsdoc/check-indentation */
+  /**
+   * Adds or updates a key-value pair in the map.
+   *
+   * Note that this method has a different behavior from the `Map.set`.
+   *
+   * - If the given key is not already present in the map, this method adds the
+   *   key-value pair to the map.
+   *
+   * - If the given key is already present in the map and the Snap IDs match,
+   *   this method updates the value associated with the key.
+   *
+   * - However, if the given key is already present in the map but the Snap IDs
+   *   do not match, this method throws an error.
+   *
+   * @param key - Key of the element to add or update.
+   * @param value - Value of the element to add or update.
+   * @returns The map itself.
+   */
+  /* eslint-enable jsdoc/check-indentation */
+  set(key: string, value: Value): this {
+    // If the key is present in the map but isn't associated with the given
+    // Snap ID, it means that the item was added to the map by a different
+    // Snap. In this case, throw an error.
+    if (this.#map.has(key) && !this.has(value.snapId, key)) {
+      throw new InvalidSnapIdError(value.snapId, key);
+    }
+    this.#map.set(key, value);
+    return this;
+  }
+
+  /**
+   * Returns an iterable of the values in the map.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap([
+   *   ['foo', { snapId: '1', name: 'foo' }],
+   *   ['bar', { snapId: '1', name: 'bar' }],
+   * ]);
+   * const values = [...map.values()];
+   * // Returns
+   * // [
+   * //   { snapId: '1', name: 'foo' },
+   * //   { snapId: '1', name: 'bar' },
+   * // ]
+   * ```
+   *
+   * @returns An iterable of the values in the map.
+   */
+  values(): IterableIterator<Value> {
+    return this.#map.values();
+  }
+
+  /**
+   * Returns the number of key-value pairs in the map.
+   *
+   * @returns The number of key-value pairs in the map.
+   */
+  get size(): number {
+    return this.#map.size;
+  }
+}


### PR DESCRIPTION
The `SnapIdMap` requires a `snapId` value to be passed to the `get`, `has`, and `delete` methods. Its goal is to ensure that the correct Snap ID must be passed, thus preventing a Snap from accessing or deleting a value from another Snap.