### PR TITLE
feat(272): add `chainId` to Keyring API requests (transaction/typed message)

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -734,6 +734,53 @@ describe('SnapKeyring', () => {
       expect(signature).toStrictEqual(expectedSignature);
     });
 
+    it('signs typed data without domain chainId has no scope', async () => {
+      mockSnapController.handleRequest.mockResolvedValue({
+        pending: false,
+        result: expectedSignature,
+      });
+
+      const dataToSignWithoutDomainChainId = {
+        ...dataToSign,
+        domain: {
+          name: dataToSign.domain.name,
+          version: dataToSign.domain.version,
+          verifyingContract: dataToSign.domain.verifyingContract,
+          // We do not defined the chainId (it's currently marked as
+          // optional in the current type declaration).
+          // chainId: 1,
+        },
+      };
+
+      const signature = await keyring.signTypedData(
+        accounts[0].address,
+        dataToSignWithoutDomainChainId,
+        { version: SignTypedDataVersion.V4 },
+      );
+      expect(mockSnapController.handleRequest).toHaveBeenCalledWith({
+        snapId,
+        handler: 'onKeyringRequest',
+        origin: 'metamask',
+        request: {
+          id: expect.any(String),
+          jsonrpc: '2.0',
+          method: 'keyring_submitRequest',
+          params: {
+            id: expect.any(String),
+            // Without chainId alongside the typed message, we cannot
+            // compute the scope for this request!
+            scope: '', // Default value for `signTypedTransaction`
+            account: accounts[0].id,
+            request: {
+              method: 'eth_signTypedData_v4',
+              params: [accounts[0].address, dataToSignWithoutDomainChainId],
+            },
+          },
+        },
+      });
+      expect(signature).toStrictEqual(expectedSignature);
+    });
+
     it('calls eth_prepareUserOperation', async () => {
       const baseTxs = [
         {

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -540,14 +540,14 @@ describe('SnapKeyring', () => {
   describe('signTransaction', () => {
     it('signs a ethereum transaction synchronously', async () => {
       const mockTx = {
-        data: '0x0',
+        data: '0x00',
         gasLimit: '0x26259fe',
         gasPrice: '0x1',
         nonce: '0xfffffffe',
         to: '0xccccccccccccd000000000000000000000000000',
         value: '0x1869e',
         chainId: '0x1',
-        type: '0x00',
+        type: '0x0',
       };
       const mockSignedTx = {
         ...mockTx,
@@ -561,7 +561,32 @@ describe('SnapKeyring', () => {
         pending: false,
         result: mockSignedTx,
       });
+
       const signature = await keyring.signTransaction(accounts[0].address, tx);
+      expect(mockSnapController.handleRequest).toHaveBeenCalledWith({
+        snapId,
+        handler: 'onKeyringRequest',
+        origin: 'metamask',
+        request: {
+          id: expect.any(String),
+          jsonrpc: '2.0',
+          method: 'keyring_submitRequest',
+          params: {
+            id: expect.any(String),
+            scope: expect.any(String),
+            account: accounts[0].id,
+            request: {
+              method: 'eth_signTransaction',
+              params: [
+                {
+                  ...mockTx,
+                  from: accounts[0].address,
+                },
+              ],
+            },
+          },
+        },
+      });
       expect(signature).toStrictEqual(expectedSignedTx);
     });
   });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -557,6 +557,8 @@ describe('SnapKeyring', () => {
       };
       const tx = TransactionFactory.fromTxData(mockTx);
       const expectedSignedTx = TransactionFactory.fromTxData(mockSignedTx);
+      const expectedScope = 'eip155:1';
+
       mockSnapController.handleRequest.mockResolvedValue({
         pending: false,
         result: mockSignedTx,
@@ -573,7 +575,7 @@ describe('SnapKeyring', () => {
           method: 'keyring_submitRequest',
           params: {
             id: expect.any(String),
-            scope: expect.any(String),
+            scope: expectedScope,
             account: accounts[0].id,
             request: {
               method: 'eth_signTransaction',
@@ -630,6 +632,7 @@ describe('SnapKeyring', () => {
       },
     };
 
+    const expectedScope = 'eip155:1';
     const expectedSignature =
       '0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c';
 
@@ -653,7 +656,7 @@ describe('SnapKeyring', () => {
           method: 'keyring_submitRequest',
           params: {
             id: expect.any(String),
-            scope: expect.any(String),
+            scope: expectedScope,
             account: accounts[0].id,
             request: {
               method: 'eth_signTypedData_v1',
@@ -686,7 +689,7 @@ describe('SnapKeyring', () => {
           method: 'keyring_submitRequest',
           params: {
             id: expect.any(String),
-            scope: expect.any(String),
+            scope: expectedScope,
             account: accounts[0].id,
             request: {
               method: 'eth_signTypedData_v4',
@@ -719,7 +722,7 @@ describe('SnapKeyring', () => {
           method: 'keyring_submitRequest',
           params: {
             id: expect.any(String),
-            scope: expect.any(String),
+            scope: expectedScope,
             account: accounts[0].id,
             request: {
               method: 'eth_signTypedData_v1',

--- a/src/caip.test.ts
+++ b/src/caip.test.ts
@@ -1,0 +1,46 @@
+import { CAIP_NAMESPACE_REGEX, CAIP_REFERENCE_REGEX } from '@metamask/utils';
+
+import { toCaipChainId, CaipNamespaces } from './caip';
+
+describe('toCaipChainId', () => {
+  // This function relies on @metamask/utils CAIP helpers. Those are being
+  // tested with a variety of inputs.
+  // Here we mainly focus on our own wrapper around those:
+
+  it('returns a valid CAIP-2 chain ID', () => {
+    const namespace = CaipNamespaces.Eip155;
+    const reference = '1';
+    expect(toCaipChainId(namespace, reference)).toBe(
+      `${namespace}:${reference}`,
+    );
+  });
+
+  it.each([
+    // Too short, must have 3 chars at least
+    '',
+    'xs',
+    // Not matching
+    '!@#$%^&*()',
+    // Too long
+    'namespacetoolong',
+  ])('throws for invalid namespaces: %s', (namespace) => {
+    const reference = '1';
+    expect(() => toCaipChainId(namespace, reference)).toThrow(
+      `Invalid "namespace", must match: ${CAIP_NAMESPACE_REGEX.toString()}`,
+    );
+  });
+
+  it.each([
+    // Too short, must have 1 char at least
+    '',
+    // Not matching
+    '!@#$%^&*()',
+    // Too long
+    '012345678901234567890123456789012', // 33 chars
+  ])('throws for invalid reference: %s', (reference) => {
+    const namespace = CaipNamespaces.Eip155;
+    expect(() => toCaipChainId(namespace, reference)).toThrow(
+      `Invalid "reference", must match: ${CAIP_REFERENCE_REGEX.toString()}`,
+    );
+  });
+});

--- a/src/caip.ts
+++ b/src/caip.ts
@@ -1,0 +1,51 @@
+import {
+  CAIP_NAMESPACE_REGEX,
+  CAIP_REFERENCE_REGEX,
+  isCaipNamespace,
+  isCaipReference,
+} from '@metamask/utils';
+import type {
+  CaipNamespace,
+  CaipReference,
+  CaipChainId,
+} from '@metamask/utils';
+
+/** Supported CAIP namespaces. */
+export const CaipNamespaces = {
+  /** Namespace for EIP-155 compatible chains. */
+  Eip155: 'eip155' as CaipNamespace,
+} as const;
+
+/**
+ * Chain ID as defined per the CAIP-2
+ * {@link https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md}.
+ *
+ * It defines a way to uniquely identify any blockchain in a human-readable
+ * way.
+ *
+ * @param namespace - The standard (ecosystem) of similar blockchains.
+ * @param reference - Identify of a blockchain within a given namespace.
+ * @throws {@link Error}
+ * This exception is thrown if the inputs does not comply with the CAIP-2
+ * syntax specification
+ * {@link https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md#syntax}.
+ * @returns A CAIP chain ID.
+ */
+export function toCaipChainId(
+  namespace: CaipNamespace,
+  reference: CaipReference,
+): CaipChainId {
+  if (!isCaipNamespace(namespace)) {
+    throw new Error(
+      `Invalid "namespace", must match: ${CAIP_NAMESPACE_REGEX.toString()}`,
+    );
+  }
+
+  if (!isCaipReference(reference)) {
+    throw new Error(
+      `Invalid "reference", must match: ${CAIP_REFERENCE_REGEX.toString()}`,
+    );
+  }
+
+  return `${namespace}:${reference}`;
+}


### PR DESCRIPTION
# Description

This is the first step of adding a CAIP-2 scope to internal requests.

It's a "first step" as for now, we cannot get/extract the `chainId` for some methods. This would require a much bigger refactor (which will come later).

## `signTransaction` requests

The `chainId` is part of the transaction request, so we extract it from there and attach it to the internal request.

## `signTypedData` (when applicable) requests

The `chainId` is part of the `domain` field (as defined by EIP-712), however, some older versions of the `eth_signTypedData_vX` might not have it! In this case, we do not provide the `scope`.

As of today, only those methods do not have the `domain`:
- `eth_signTypedData`
- `eth_signTypedData_v1`

# Related issues

- Partially fixes: [MetaMask/accounts-planning#272](https://github.com/MetaMask/accounts-planning/issues/272)

# Testing

## Manual testing

### Prerequisites

1. Use the [SSK](https://metamask.github.io/snap-simple-keyring/latest/)
1. Create a snap account (or use an existing one)
1. Enable "Use Synchronous Approval"

### 1. Transaction

1. Send a transaction using your snap account
1. **DO NOT APPROVE YET**
1. List requests using the SSK
1. You should see a scope like: `eip155:${chainId}` (depending on which chain you are using)

### 2. Typed data

1. Use the [E2E dapp](https://metamask.github.io/test-dapp/)
1. Connect to your snap account
1. Sign typed data (using any version you want)
1. **DO NOT APPROVE YET**
1. List requests using the SSK
1. You should see a scope like: `eip155:${chainId}` (depending on which chain you are using)

## Test coverage report

Coverage remains at 100%

File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------------|---------|----------|---------|---------|-------------------
All files                       |     100 |      100 |     100 |     100 |
 CaseInsensitiveMap.ts          |     100 |      100 |     100 |     100 |
 DeferredPromise.ts             |     100 |      100 |     100 |     100 |
 KeyringSnapControllerClient.ts |     100 |      100 |     100 |     100 |
 SnapIdMap.ts                   |     100 |      100 |     100 |     100 |
 SnapKeyring.ts                 |     100 |      100 |     100 |     100 |
 caip.ts                        |     100 |      100 |     100 |     100 |
 index.ts                       |     100 |      100 |     100 |     100 |
 types.ts                       |     100 |      100 |     100 |     100 |
 util.ts                        |     100 |      100 |     100 |     100 |

## Jest

Added a new test for CAIP helpers:
```console
yarn jest src/caip.test.ts
```

Updated test regarding transaction flow:
```console
yarn jest src/SnapKeyring.test.ts
```