### PR TITLE
fix: enforce that responses of `prepareUserOperation` and `patchUserOperation` are synchronous

### DIFF
--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -14,6 +14,9 @@ import type { SnapId } from '@metamask/snaps-sdk';
 import type { KeyringState } from '.';
 import { SnapKeyring } from '.';
 
+const regexForUUIDInRequiredSyncErrorMessage =
+  /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u;
+
 describe('SnapKeyring', () => {
   let keyring: SnapKeyring;
 
@@ -1247,9 +1250,7 @@ describe('SnapKeyring', () => {
 
       await expect(
         keyring.prepareUserOperation(accounts[0].address, mockIntents),
-      ).rejects.toThrow(
-        /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u,
-      );
+      ).rejects.toThrow(regexForUUIDInRequiredSyncErrorMessage);
     });
   });
 
@@ -1308,9 +1309,7 @@ describe('SnapKeyring', () => {
 
       await expect(
         keyring.patchUserOperation(accounts[0].address, mockUserOp),
-      ).rejects.toThrow(
-        /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u,
-      );
+      ).rejects.toThrow(regexForUUIDInRequiredSyncErrorMessage);
     });
   });
 });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -1210,6 +1210,7 @@ describe('SnapKeyring', () => {
       dummyPaymasterAndData: '0x',
       bundlerUrl: 'https://bundler.example.com/rpc',
     };
+
     it('calls eth_prepareUserOperation', async () => {
       mockSnapController.handleRequest.mockReturnValueOnce({
         pending: false,

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -1,6 +1,11 @@
 import { TransactionFactory } from '@ethereumjs/tx';
 import { SignTypedDataVersion } from '@metamask/eth-sig-util';
-import type { KeyringAccount } from '@metamask/keyring-api';
+import type {
+  EthBaseUserOperation,
+  EthUserOperation,
+  EthUserOperationPatch,
+  KeyringAccount,
+} from '@metamask/keyring-api';
 import { EthAccountType, EthMethod } from '@metamask/keyring-api';
 import { KeyringEvent } from '@metamask/keyring-api/dist/events';
 import type { SnapController } from '@metamask/snaps-controllers';
@@ -1180,6 +1185,131 @@ describe('SnapKeyring', () => {
           keyring: { type: 'Snap Keyring' },
         },
       });
+    });
+  });
+
+  describe('prepareUserOperation', () => {
+    const mockIntents = [
+      {
+        to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
+        value: '0x0',
+        data: '0x',
+      },
+    ];
+
+    const mockExpectedUserOp: EthBaseUserOperation = {
+      callData: '0x70641a22000000000000000000000000f3de3c0d654fda23da',
+      initCode: '0x',
+      nonce: '0x1',
+      gasLimits: {
+        callGasLimit: '0x58a83',
+        verificationGasLimit: '0xe8c4',
+        preVerificationGas: '0xc57c',
+      },
+      dummySignature: '0x',
+      dummyPaymasterAndData: '0x',
+      bundlerUrl: 'https://bundler.example.com/rpc',
+    };
+    it('calls eth_prepareUserOperation', async () => {
+      mockSnapController.handleRequest.mockReturnValueOnce({
+        pending: false,
+        result: mockExpectedUserOp,
+      });
+
+      await keyring.prepareUserOperation(accounts[0].address, mockIntents);
+
+      expect(mockSnapController.handleRequest).toHaveBeenCalledWith({
+        handler: 'onKeyringRequest',
+        origin: 'metamask',
+        request: {
+          id: expect.any(String),
+          jsonrpc: '2.0',
+          method: 'keyring_submitRequest',
+          params: {
+            id: expect.any(String),
+            scope: expect.any(String),
+            account: accounts[0].id,
+            request: {
+              method: 'eth_prepareUserOperation',
+              params: mockIntents,
+            },
+          },
+        },
+        snapId: 'local:snap.mock',
+      });
+    });
+
+    it('throws error if an pending response is returned from the snap', async () => {
+      mockSnapController.handleRequest.mockReturnValueOnce({
+        pending: true,
+      });
+
+      await expect(
+        keyring.prepareUserOperation(accounts[0].address, mockIntents),
+      ).rejects.toThrow(
+        /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u,
+      );
+    });
+  });
+
+  describe('patchUserOperation', () => {
+    const mockUserOp: EthUserOperation = {
+      sender: accounts[0].address,
+      callData: '0x70641a22000000000000000000000000f3de3c0d654fda23da',
+      initCode: '0x',
+      nonce: '0x1',
+      callGasLimit: '0x58a83',
+      verificationGasLimit: '0xe8c4',
+      preVerificationGas: '0xc57c',
+      maxFeePerGas: '0x87f0878c0',
+      maxPriorityFeePerGas: '0x1dcd6500',
+      signature: '0x',
+      paymasterAndData: '0x',
+    };
+
+    const mockExpectedPatch: EthUserOperationPatch = {
+      paymasterAndData: '0x1234',
+    };
+
+    it('calls eth_patchUserOperation', async () => {
+      mockSnapController.handleRequest.mockReturnValueOnce({
+        pending: false,
+        result: mockExpectedPatch,
+      });
+
+      await keyring.patchUserOperation(accounts[0].address, mockUserOp);
+
+      expect(mockSnapController.handleRequest).toHaveBeenCalledWith({
+        handler: 'onKeyringRequest',
+        origin: 'metamask',
+        request: {
+          id: expect.any(String),
+          jsonrpc: '2.0',
+          method: 'keyring_submitRequest',
+          params: {
+            id: expect.any(String),
+            scope: expect.any(String),
+            account: accounts[0].id,
+            request: {
+              method: 'eth_patchUserOperation',
+              params: [mockUserOp],
+            },
+          },
+        },
+        snapId: 'local:snap.mock',
+      });
+    });
+
+    it('throws error if an pending response is returned from the snap', async () => {
+      mockSnapController.handleRequest.mockReturnValueOnce({
+        pending: true,
+      });
+
+      await expect(
+        keyring.patchUserOperation(accounts[0].address, mockUserOp),
+      ).rejects.toThrow(
+        /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u,
+      );
     });
   });
 });

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -15,7 +15,7 @@ import type { KeyringState } from '.';
 import { SnapKeyring } from '.';
 
 const regexForUUIDInRequiredSyncErrorMessage =
-  /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and requireSync is true/u;
+  /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and expectSync is true/u;
 
 describe('SnapKeyring', () => {
   let keyring: SnapKeyring;

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -385,7 +385,7 @@ export class SnapKeyring extends EventEmitter {
    * @param opts.method - Method to call.
    * @param opts.params - Method parameters.
    * @param opts.chainId - Selected chain ID (CAIP-2).
-   * @param opts.requireSync - Whether the request should be synchronous.
+   * @param opts.expectSync - Whether the request should be synchronous.
    * @returns Promise that resolves to the result of the method call.
    */
   async #submitRequest<Response extends Json>({
@@ -393,13 +393,13 @@ export class SnapKeyring extends EventEmitter {
     method,
     params,
     chainId = '',
-    requireSync = false,
+    expectSync = false,
   }: {
     address: string;
     method: string;
     params?: Json[] | Record<string, Json>;
     chainId?: string;
-    requireSync?: boolean;
+    expectSync?: boolean;
   }): Promise<Json> {
     const { account, snapId } = this.#resolveAddress(address);
     if (!this.#hasMethod(account, method as EthMethod)) {
@@ -426,9 +426,9 @@ export class SnapKeyring extends EventEmitter {
     // Some methods, like the ones used to prepare and patch user operations,
     // require the Snap to answer synchronously in order to work with the
     // confirmation flow. This check lets the caller enforce this behavior.
-    if (requireSync && response.pending) {
+    if (expectSync && response.pending) {
       throw new Error(
-        `Request '${requestId}' to snap '${snapId}' is pending and requireSync is true.`,
+        `Request '${requestId}' to snap '${snapId}' is pending and expectSync is true.`,
       );
     }
 
@@ -719,7 +719,7 @@ export class SnapKeyring extends EventEmitter {
         address,
         method: EthMethod.PrepareUserOperation,
         params: toJson<Json[]>(transactions),
-        requireSync: true,
+        expectSync: true,
       }),
       EthBaseUserOperationStruct,
     );
@@ -742,7 +742,7 @@ export class SnapKeyring extends EventEmitter {
         address,
         method: EthMethod.PatchUserOperation,
         params: toJson<Json[]>([userOp]),
-        requireSync: true,
+        expectSync: true,
       }),
       EthUserOperationPatchStruct,
     );

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -423,6 +423,9 @@ export class SnapKeyring extends EventEmitter {
       chainId,
     });
 
+    // Some methods, like the ones used to prepare and patch user operations,
+    // require the Snap to answer synchronously in order to work with the
+    // confirmation flow. This check lets the caller enforce this behavior.
     if (requireSync && response.pending) {
       throw new Error(
         `Request '${requestId}' to snap '${snapId}' is pending and requireSync is true.`,

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -761,7 +761,6 @@ export class SnapKeyring extends EventEmitter {
         address,
         method: EthMethod.SignUserOperation,
         params: toJson<Json[]>([userOp]),
-        requireSync: true,
       }),
       EthBytesStruct,
     );


### PR DESCRIPTION
This pull request adds tests for the `prepareUserOperation` and `patchUserOperation` methods in the `SnapKeyring` class. The tests ensure that the methods correctly handle requests to the Snap and handle pending responses.

Resolves: metamask/accounts-planning#290