### PR TITLE
feat: add logger + now log Snap requests

### DIFF
--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -35,6 +35,7 @@ import { v4 as uuid } from 'uuid';
 import { toCaipChainId, CaipNamespaces } from './caip';
 import { DeferredPromise } from './DeferredPromise';
 import { KeyringSnapControllerClient } from './KeyringSnapControllerClient';
+import { projectLogger as log } from './logger';
 import { SnapIdMap } from './SnapIdMap';
 import type { SnapMessage } from './types';
 import { SnapMessageStruct } from './types';
@@ -502,7 +503,7 @@ export class SnapKeyring extends EventEmitter {
     chainId: string;
   }): Promise<KeyringResponse> {
     try {
-      return await this.#snapClient.withSnapId(snapId).submitRequest({
+      const request = {
         id: requestId,
         scope: chainId,
         account: account.id,
@@ -510,8 +511,14 @@ export class SnapKeyring extends EventEmitter {
           method,
           ...(params !== undefined && { params }),
         },
-      });
+      };
+
+      log('Submit Snap request: ', request);
+
+      return await this.#snapClient.withSnapId(snapId).submitRequest(request);
     } catch (error) {
+      log('Snap Request failed: ', { requestId });
+
       // If the Snap failed to respond, delete the promise to prevent a leak.
       this.#requests.delete(snapId, requestId);
       throw error;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('eth-snap-keyring');
+
+export { createModuleLogger };


### PR DESCRIPTION
## Description

This uses the same logging mechanism than the extension (using `@metamask/utils` logging).

You can configure the logger using the `DEBUG` "env variable" from your `.metamaskrc`. Every MetaMask logs are prefixed by `metamask:`.

In our case, the log prefix would be: `metamask:eth-snap-keyring`.

## Screenshots

![Screenshot 2024-03-14 at 12 26 04](https://github.com/MetaMask/eth-snap-keyring/assets/569258/52070b2c-c085-4032-9de0-62c813cf45cf)
![Screenshot 2024-03-14 at 12 26 18](https://github.com/MetaMask/eth-snap-keyring/assets/569258/935e2a94-6438-4fe3-8ea1-8aad7d712888)

## Manual testing

Add this resolution to your extension's `package.json`:

```json
...
"resolutions": {
  "@metamask/eth-snap-keyring@^2.2.0": "metamask/eth-snap-keyring#fb923891d9497ad4b207191699e79f364aad74ce",
},
... 
```

> You might need more version resolutions depending on your dependency, you can check them with `yarn why @metamask/eth-snap-keyring`

Then, run some actions (using the e2e dapp for example) and check logs of your extension (see the screenshots for an example).

## Note

For now we do log every Snap requests (and only the `requestId` in case of failure). I thought that "masking" some properties would be great (using `superstruct`), however the Snap controller already logs the entire request object, so I guess this is "ok".

> You can check that by filtering the logs in your console with `metamask:snaps:snaps-controllers`