### PR TITLE
chore(deps): bump @metamask/keyring-api from 5.0.0 to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/keyring-api": "^5.0.0",
+    "@metamask/keyring-api": "^5.1.0",
     "@metamask/snaps-controllers": "^6.0.3",
     "@metamask/snaps-sdk": "^3.1.1",
     "@metamask/snaps-utils": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,7 +1060,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/keyring-api": ^5.0.0
+    "@metamask/keyring-api": ^5.1.0
     "@metamask/snaps-controllers": ^6.0.3
     "@metamask/snaps-sdk": ^3.1.1
     "@metamask/snaps-utils": ^7.0.3
@@ -1142,17 +1142,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/keyring-api@npm:5.0.0"
+"@metamask/keyring-api@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@metamask/keyring-api@npm:5.1.0"
   dependencies:
-    "@metamask/providers": ^16.0.0
     "@metamask/snaps-sdk": ^3.1.1
     "@metamask/utils": ^8.3.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: a1219fa1990f02bb341c1ac54468e355fed5ae7a4a5662dd8a00a636e790aeba3a0f92961779b9fc61275bcdca7775d0a752470957c4a79203bb5144ba3928d5
+  peerDependencies:
+    "@metamask/providers": ">=15 <17"
+  checksum: 37cc4d35116285762be7167f294a31add9a978eca7652af014355ce691c9b90cfeb52ab8732ebc59d413aeb7ac87e785e4a2a49fd44d3c1563f3796e4ac1bb8f
   languageName: node
   linkType: hard
 
@@ -1255,26 +1256,6 @@ __metadata:
     readable-stream: ^3.6.2
     webextension-polyfill: ^0.10.0
   checksum: 42571450e79d69d943384f557f6a61e0f73101d49804fb6e8075d791959f76c42b8ff626f711d434674792d77aead6cb8a32b04a3dcd53598c8aff24cbb1ad25
-  languageName: node
-  linkType: hard
-
-"@metamask/providers@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@metamask/providers@npm:16.0.0"
-  dependencies:
-    "@metamask/json-rpc-engine": ^7.3.2
-    "@metamask/json-rpc-middleware-stream": ^6.0.2
-    "@metamask/object-multiplex": ^2.0.0
-    "@metamask/rpc-errors": ^6.2.1
-    "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.3.0
-    detect-browser: ^5.2.0
-    extension-port-stream: ^3.0.0
-    fast-deep-equal: ^3.1.3
-    is-stream: ^2.0.0
-    readable-stream: ^3.6.2
-    webextension-polyfill: ^0.10.0
-  checksum: cdc06796111edbf01e9aa8498170f7ffa3c68a4c0f66a629e3b0f7d37ee60eb32d83ee12f285c3d974d971c6af16a3fba531fb5733f5fa9412a18e1d3f648539
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bump `@metamask/keyring-api` from 5.0.0 to 5.1.0. 