### PR TITLE
chore(deps): bump @metamask/utils from 8.3.0 to 8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@metamask/snaps-controllers": "^6.0.3",
     "@metamask/snaps-sdk": "^3.1.1",
     "@metamask/snaps-utils": "^7.0.3",
-    "@metamask/utils": "^8.3.0",
+    "@metamask/utils": "^8.4.0",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",
     "uuid": "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@ __metadata:
     "@metamask/snaps-controllers": ^6.0.3
     "@metamask/snaps-sdk": ^3.1.1
     "@metamask/snaps-utils": ^7.0.3
-    "@metamask/utils": ^8.3.0
+    "@metamask/utils": ^8.4.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
     "@types/uuid": ^9.0.1
@@ -1458,7 +1458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0":
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:


### PR DESCRIPTION
## Description

Even though this bump might not seems necessary, it emphasis the fact that we do now require the `8.4.0` of `@metamask/utils` that provides the new CAIP helpers.