### PR TITLE
chore(deps): update @metamask/keyring-api to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/keyring-api": "^5.1.0",
+    "@metamask/keyring-api": "^6.0.0",
     "@metamask/snaps-controllers": "^7.0.1",
     "@metamask/snaps-sdk": "^4.0.1",
     "@metamask/snaps-utils": "^7.0.3",

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -1169,6 +1169,7 @@ describe('SnapKeyring', () => {
         ...a,
         metadata: {
           name: '',
+          importTime: 0,
           snap: snapMetadata,
           keyring: {
             type: 'Snap Keyring',
@@ -1202,6 +1203,7 @@ describe('SnapKeyring', () => {
         ...accounts[0],
         metadata: {
           name: '',
+          importTime: 0,
           snap: { id: snapId, name: 'snap-name', enabled: true },
           keyring: { type: 'Snap Keyring' },
         },

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -912,6 +912,7 @@ export class SnapKeyring extends EventEmitter {
         address: account.address.toLowerCase(),
         metadata: {
           name: '',
+          importTime: 0,
           keyring: {
             type: this.type,
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/keyring-api": ^5.1.0
+    "@metamask/keyring-api": ^6.0.0
     "@metamask/snaps-controllers": ^7.0.1
     "@metamask/snaps-sdk": ^4.0.1
     "@metamask/snaps-utils": ^7.0.3
@@ -1167,18 +1167,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@metamask/keyring-api@npm:5.1.0"
+"@metamask/keyring-api@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/keyring-api@npm:6.0.0"
   dependencies:
-    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/snaps-sdk": ^4.0.0
     "@metamask/utils": ^8.3.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
   peerDependencies:
     "@metamask/providers": ">=15 <17"
-  checksum: 37cc4d35116285762be7167f294a31add9a978eca7652af014355ce691c9b90cfeb52ab8732ebc59d413aeb7ac87e785e4a2a49fd44d3c1563f3796e4ac1bb8f
+  checksum: d3d6d5d27945783ef74e8e1b9626d122a07df58a2a62e12c68ff0bda2894c6c0a16d6add40908159fb92dee0b98425c63fc494c9b86ae0d0a0be7dc74389997a
   languageName: node
   linkType: hard
 
@@ -1359,20 +1359,6 @@ __metadata:
     "@noble/hashes": ^1.3.1
     superstruct: ^1.0.3
   checksum: 219e166b9a1b0653db8c679319ee9022244e697575023dcccbab571faf9411bf88e1139049745a4d7949c1e6a4ae621e20a5e5e4c31f8b68e1f146117f0b8150
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-sdk@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "@metamask/snaps-sdk@npm:3.2.0"
-  dependencies:
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/providers": ^16.0.0
-    "@metamask/rpc-errors": ^6.2.1
-    "@metamask/utils": ^8.3.0
-    fast-xml-parser: ^4.3.4
-    superstruct: ^1.0.3
-  checksum: a95f10403b50be7b6b35b49eef3724eabb8ef0763db6434e6c77a6d56fb18deab928764dee2738ee6428e77ea582b3dd71e5cbdb19dfb37389dc4c6d34294891
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request updates the @metamask/keyring-api dependency to version 6.0.0. It also includes a chore commit to bump the keyring-api version.