### PR TITLE
Bump @metamask/keyring-api to version 6.1.0 and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/keyring-api": "^6.0.0",
+    "@metamask/keyring-api": "^6.1.0",
     "@metamask/snaps-controllers": "^8.0.0",
     "@metamask/snaps-sdk": "^4.0.1",
     "@metamask/snaps-utils": "^7.0.3",

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -74,7 +74,7 @@ describe('SnapKeyring', () => {
   };
   const btcP2wpkhAccount = {
     id: '11cffca0-12cc-4779-8f82-23273c062e29',
-    address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'.toLowerCase(),
+    address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'.toLowerCase(),
     options: {},
     methods: [...Object.values(BtcMethod)],
     type: BtcAccountType.P2wpkh,

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -1165,9 +1165,9 @@ describe('SnapKeyring', () => {
       mockSnapController.handleRequest.mockResolvedValue(null);
       await keyring.removeAccount(ethEoaAccount1.address);
       expect(await keyring.getAccounts()).toStrictEqual([
-        ethEoaAccount2.address.toLowerCase(),
-        accounts[2].address.toLowerCase(),
-        accounts[3].address.toLowerCase(),
+        ethEoaAccount2.address,
+        accounts[2].address,
+        accounts[3].address,
       ]);
     });
 
@@ -1176,9 +1176,9 @@ describe('SnapKeyring', () => {
       mockSnapController.handleRequest.mockRejectedValue('some error');
       await keyring.removeAccount(ethEoaAccount1.address);
       expect(await keyring.getAccounts()).toStrictEqual([
-        ethEoaAccount2.address.toLowerCase(),
-        accounts[2].address.toLowerCase(),
-        accounts[3].address.toLowerCase(),
+        ethEoaAccount2.address,
+        accounts[2].address,
+        accounts[3].address,
       ]);
       expect(console.error).toHaveBeenCalledWith(
         "Account '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3' may not have been removed from snap 'local:snap.mock':",

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -55,7 +55,8 @@ import {
 
 export const SNAP_KEYRING_TYPE = 'Snap Keyring';
 
-// Temp to remove when this is added to the keyring-api
+// TODO: to be removed when this is added to the keyring-api
+
 type AccountMethod = EthMethod | EthErc4337Method | BtcMethod;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,10 +1062,10 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/keyring-api": ^6.0.0
+    "@metamask/keyring-api": ^6.1.0
     "@metamask/snaps-controllers": ^8.0.0
     "@metamask/snaps-sdk": ^4.0.1
-    "@metamask/snaps-utils": ^7.0.3
+    "@metamask/snaps-utils": ^7.2.0
     "@metamask/utils": ^8.4.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
@@ -1144,18 +1144,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/keyring-api@npm:6.0.0"
+"@metamask/keyring-api@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/keyring-api@npm:6.1.0"
   dependencies:
     "@metamask/snaps-sdk": ^4.0.0
     "@metamask/utils": ^8.3.0
     "@types/uuid": ^9.0.1
+    bech32: ^2.0.0
     superstruct: ^1.0.3
     uuid: ^9.0.0
   peerDependencies:
     "@metamask/providers": ">=15 <17"
-  checksum: d3d6d5d27945783ef74e8e1b9626d122a07df58a2a62e12c68ff0bda2894c6c0a16d6add40908159fb92dee0b98425c63fc494c9b86ae0d0a0be7dc74389997a
+  checksum: 493aff0569b2f62a9cbbda82e5b9df709562f5f11d32f5d97224a7d29be1bbd7139e23f1384d9d888e2e90d3858e64ff499c03780b3664d31724a054722b4e0a
   languageName: node
   linkType: hard
 
@@ -1354,7 +1355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.0.3, @metamask/snaps-utils@npm:^7.1.0, @metamask/snaps-utils@npm:^7.2.0":
+"@metamask/snaps-utils@npm:^7.1.0, @metamask/snaps-utils@npm:^7.2.0":
   version: 7.2.0
   resolution: "@metamask/snaps-utils@npm:7.2.0"
   dependencies:
@@ -2420,6 +2421,13 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
+  languageName: node
+  linkType: hard
+
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: fa15acb270b59aa496734a01f9155677b478987b773bf701f465858bf1606c6a970085babd43d71ce61895f1baa594cb41a2cd1394bd2c6698f03cc2d811300e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,7 +1065,7 @@ __metadata:
     "@metamask/keyring-api": ^6.1.0
     "@metamask/snaps-controllers": ^8.0.0
     "@metamask/snaps-sdk": ^4.0.1
-    "@metamask/snaps-utils": ^7.2.0
+    "@metamask/snaps-utils": ^7.0.3
     "@metamask/utils": ^8.4.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
@@ -1355,7 +1355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.1.0, @metamask/snaps-utils@npm:^7.2.0":
+"@metamask/snaps-utils@npm:^7.0.3, @metamask/snaps-utils@npm:^7.1.0, @metamask/snaps-utils@npm:^7.2.0":
   version: 7.2.0
   resolution: "@metamask/snaps-utils@npm:7.2.0"
   dependencies:


### PR DESCRIPTION
This pull request updates the @metamask/keyring-api dependency to version 6.1.0 and fixes tests.