### PR TITLE
chore(deps): replace 'superstruct' imports with '@metamask/superstruct'

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "@metamask/snaps-controllers": "^8.1.1",
     "@metamask/snaps-sdk": "^4.2.0",
     "@metamask/snaps-utils": "^7.4.0",
-    "@metamask/utils": "^8.4.0",
-    "@types/uuid": "^9.0.1",
     "@metamask/superstruct": "^3.0.0",
+    "@metamask/utils": "^8.5.0",
+    "@types/uuid": "^9.0.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@metamask/snaps-utils": "^7.4.0",
     "@metamask/utils": "^8.4.0",
     "@types/uuid": "^9.0.1",
-    "superstruct": "^1.0.3",
+    "@metamask/superstruct": "^3.0.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -28,6 +28,7 @@ import {
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Snap } from '@metamask/snaps-utils';
+import { assert, mask, object, string } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 import {
   bigIntToHex,
@@ -35,7 +36,6 @@ import {
   toCaipChainId,
 } from '@metamask/utils';
 import { EventEmitter } from 'events';
-import { assert, mask, object, string } from '@metamask/superstruct';
 import { v4 as uuid } from 'uuid';
 
 import { DeferredPromise } from './DeferredPromise';

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -35,7 +35,7 @@ import {
   toCaipChainId,
 } from '@metamask/utils';
 import { EventEmitter } from 'events';
-import { assert, mask, object, string } from 'superstruct';
+import { assert, mask, object, string } from '@metamask/superstruct';
 import { v4 as uuid } from 'uuid';
 
 import { DeferredPromise } from './DeferredPromise';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { array, object, optional, record, string, union } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
+import { array, object, optional, record, string, union } from '@metamask/superstruct';
 
 export const SnapMessageStruct = object({
   method: string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,13 @@
-import { JsonStruct } from '@metamask/utils';
 import type { Infer } from '@metamask/superstruct';
-import { array, object, optional, record, string, union } from '@metamask/superstruct';
+import {
+  array,
+  object,
+  optional,
+  record,
+  string,
+  union,
+} from '@metamask/superstruct';
+import { JsonStruct } from '@metamask/utils';
 
 export const SnapMessageStruct = object({
   method: string(),

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
-import type { Struct } from 'superstruct';
-import { assert } from 'superstruct';
+import type { Struct } from '@metamask/superstruct';
+import { assert } from '@metamask/superstruct';
 
 /**
  * Assert that a value is valid according to a struct.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
-import type { Json } from '@metamask/utils';
 import type { Struct } from '@metamask/superstruct';
 import { assert } from '@metamask/superstruct';
+import type { Json } from '@metamask/utils';
 
 /**
  * Assert that a value is valid according to a struct.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,7 +1066,8 @@ __metadata:
     "@metamask/snaps-controllers": ^8.1.1
     "@metamask/snaps-sdk": ^4.2.0
     "@metamask/snaps-utils": ^7.4.0
-    "@metamask/utils": ^8.4.0
+    "@metamask/superstruct": ^3.0.0
+    "@metamask/utils": ^8.5.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
     "@types/uuid": ^9.0.1
@@ -1086,7 +1087,6 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
     rimraf: ^3.0.2
-    superstruct: ^1.0.3
     ts-jest: ^28.0.7
     ts-node: ^10.7.0
     typedoc: ^0.23.15
@@ -1385,6 +1385,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/superstruct@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/superstruct@npm:3.0.0"
+  checksum: 667f8f2947186972516bb72b4ba215eaeede257c8beb0450583dd4c8b00c28729ff938267ca8804a3a351277fd627b8607cafeb71eb7045a2b6930639bb6a341
+  languageName: node
+  linkType: hard
+
 "@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
@@ -1399,6 +1406,23 @@ __metadata:
     superstruct: ^1.0.3
     uuid: ^9.0.1
   checksum: b0397e97bac7192f6189a8625a2dfcb56d3c2cf4dd2cb3d4e012a7e9786f04f59f6917805544bc131a6dacd2c8344e237ae43ad47429bb5eb35c6cf1248440b4
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "@metamask/utils@npm:8.5.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.0.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: e8eac1c796c3f6b623be3c2736e8682248620f666b180f5c12ce56ee09587d4e28b6811862139a05c7a1bec91415f10ccf0516f3cdf342f88b0189d2a057c24b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

As part of the Wallet Framework Team's OKR (Q2 2024 O3KR4) for upgrading TypeScript to v5.0+ in the core monorepo, we are updating dependencies of the core repo so that they generate builds and type declarations for both CJS and ESM.

This requirement applies to nested dependencies as well, so we are also replacing `superstruct` with the ESM-compatible fork `@metamask/superstruct` in all core dependency packages.

## Description

- [x] Replace `superstruct` dependency with `@metamask/superstruct` `^3.0.0`.
  - [x] `^3.1.0`
- [x] Replace all `superstruct` import statements with `@metamask/superstruct`
- [x] Bump `@metamask/utils` to `^8.5.0`.
  - [x] `^9.0.0`
- [x] If feasible without too much additional work:
  - [ ] ~Bump `typescript` to `~5.0.4`~
  - [ ] Set tsconfig options `module` and `moduleResolution` to `NodeNext`.
    - Incomplete due to https://github.com/MetaMask/eth-snap-keyring/issues/323
- [ ] Using the `create-release-pr` github action, publish a new release containing these changes.

## References

- Closes https://github.com/MetaMask/eth-snap-keyring/issues/310
- Blocked by https://github.com/MetaMask/eth-snap-keyring/issues/323
  - Blocked by https://github.com/MetaMask/keyring-api/pull/328
    - Blocked by https://github.com/MetaMask/snaps/pull/2445

## Changelog

```md
## [4.3.2]
### Changed
- Bump `@metamask/keyring-api` from `^8.0.0` to `^8.0.1`. ([#311](https://github.com/MetaMask/eth-snap-keyring/pull/311))
- Bump `@metamask/snaps-sdk` from `^4.2.0` to `^6.0.1`. ([#311](https://github.com/MetaMask/eth-snap-keyring/pull/311))
- Bump `@metamask/snaps-utils` from `^7.4.0` to `^7.7.1`. ([#311](https://github.com/MetaMask/eth-snap-keyring/pull/311))
- Bump `@metamask/utils` from `^8.4.0` to `^9.0.0` ([#311](https://github.com/MetaMask/eth-snap-keyring/pull/311))

### Fixed
- Replace `superstruct` with ESM-compatible `@metamask/superstruct` `^3.1.0` ([#311](https://github.com/MetaMask/eth-snap-keyring/pull/311))
  - This fixes the issue of this package being unusable by any TypeScript project that uses `Node16` or `NodeNext` as its `moduleResolution` option.
```