### PR TITLE
fix: 4337 methods from keyring-api 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/keyring-api": "^6.2.1",
+    "@metamask/keyring-api": "^6.3.1",
     "@metamask/snaps-controllers": "^8.1.1",
     "@metamask/snaps-sdk": "^4.2.0",
     "@metamask/snaps-utils": "^7.4.0",

--- a/src/SnapKeyring.test.ts
+++ b/src/SnapKeyring.test.ts
@@ -11,7 +11,6 @@ import {
   BtcAccountType,
   BtcMethod,
   EthAccountType,
-  EthErc4337Method,
   EthMethod,
 } from '@metamask/keyring-api';
 import { KeyringEvent } from '@metamask/keyring-api/dist/events';
@@ -24,6 +23,21 @@ import { SnapKeyring } from '.';
 
 const regexForUUIDInRequiredSyncErrorMessage =
   /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and expectSync is true/u;
+
+const ETH_4337_METHODS = [
+  EthMethod.PatchUserOperation,
+  EthMethod.PrepareUserOperation,
+  EthMethod.SignUserOperation,
+];
+
+const ETH_EOA_METHODS = [
+  EthMethod.PersonalSign,
+  EthMethod.Sign,
+  EthMethod.SignTransaction,
+  EthMethod.SignTypedDataV1,
+  EthMethod.SignTypedDataV3,
+  EthMethod.SignTypedDataV4,
+];
 
 describe('SnapKeyring', () => {
   let keyring: SnapKeyring;
@@ -62,21 +76,21 @@ describe('SnapKeyring', () => {
     id: 'b05d918a-b37c-497a-bb28-3d15c0d56b7a',
     address: '0xC728514Df8A7F9271f4B7a4dd2Aa6d2D723d3eE3'.toLowerCase(),
     options: {},
-    methods: [...Object.values(EthMethod)],
+    methods: ETH_EOA_METHODS,
     type: EthAccountType.Eoa,
   };
   const ethEoaAccount2 = {
     id: '33c96b60-2237-488e-a7bb-233576f3d22f',
     address: '0x34b13912eAc00152bE0Cb409A301Ab8E55739e63'.toLowerCase(),
     options: {},
-    methods: [...Object.values(EthMethod)],
+    methods: ETH_EOA_METHODS,
     type: EthAccountType.Eoa,
   };
   const ethEoaAccount3 = {
     id: 'c6697bcf-5710-4751-a1cb-340e4b50617a',
     address: '0xab1G3q98V7C67T9103g30C0417610237A137d763'.toLowerCase(),
     options: {},
-    methods: [...Object.values(EthMethod)],
+    methods: ETH_EOA_METHODS,
     type: EthAccountType.Eoa,
   };
 
@@ -84,7 +98,7 @@ describe('SnapKeyring', () => {
     id: 'fc926fff-f515-4eb5-9952-720bbd9b9849',
     address: '0x2f15b30952aebe0ed5fdbfe5bf16fb9ecdb31d9a'.toLowerCase(),
     options: {},
-    methods: [...Object.values(EthErc4337Method)],
+    methods: ETH_4337_METHODS,
     type: EthAccountType.Erc4337,
   };
   const btcP2wpkhAccount = {

--- a/src/SnapKeyring.ts
+++ b/src/SnapKeyring.ts
@@ -19,7 +19,6 @@ import {
   AccountUpdatedEventStruct,
   EthBaseUserOperationStruct,
   EthBytesStruct,
-  EthErc4337Method,
   EthMethod,
   EthUserOperationPatchStruct,
   KeyringEvent,
@@ -57,7 +56,7 @@ export const SNAP_KEYRING_TYPE = 'Snap Keyring';
 
 // TODO: to be removed when this is added to the keyring-api
 
-type AccountMethod = EthMethod | EthErc4337Method | BtcMethod;
+type AccountMethod = EthMethod | BtcMethod;
 
 /**
  * Snap keyring state.
@@ -743,7 +742,7 @@ export class SnapKeyring extends EventEmitter {
     return strictMask(
       await this.#submitRequest({
         address,
-        method: EthErc4337Method.PrepareUserOperation,
+        method: EthMethod.PrepareUserOperation,
         params: toJson<Json[]>(transactions),
         expectSync: true,
         // We assume the chain ID is already well formatted
@@ -770,7 +769,7 @@ export class SnapKeyring extends EventEmitter {
     return strictMask(
       await this.#submitRequest({
         address,
-        method: EthErc4337Method.PatchUserOperation,
+        method: EthMethod.PatchUserOperation,
         params: toJson<Json[]>([userOp]),
         expectSync: true,
         // We assume the chain ID is already well formatted
@@ -796,7 +795,7 @@ export class SnapKeyring extends EventEmitter {
     return strictMask(
       await this.#submitRequest({
         address,
-        method: EthErc4337Method.SignUserOperation,
+        method: EthMethod.SignUserOperation,
         params: toJson<Json[]>([userOp]),
         // We assume the chain ID is already well formatted
         chainId: toCaipChainId(KnownCaipNamespace.Eip155, context.chainId),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/keyring-api": ^6.2.1
+    "@metamask/keyring-api": ^6.3.1
     "@metamask/snaps-controllers": ^8.1.1
     "@metamask/snaps-sdk": ^4.2.0
     "@metamask/snaps-utils": ^7.4.0
@@ -1154,9 +1154,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "@metamask/keyring-api@npm:6.2.1"
+"@metamask/keyring-api@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@metamask/keyring-api@npm:6.3.1"
   dependencies:
     "@metamask/snaps-sdk": ^4.2.0
     "@metamask/utils": ^8.4.0
@@ -1166,7 +1166,7 @@ __metadata:
     uuid: ^9.0.1
   peerDependencies:
     "@metamask/providers": ">=15 <17"
-  checksum: e19860c7472086653a0399b6e32c693794147e8dfce5ac3c0d50115181b6821adac01c3f150c2170ec9a72b90c2a84dafce683f5a033d548449e9e311087a05a
+  checksum: d9b5164b8fbd583dd641c917153ef9264cfb236fbe49f77351f495822f1b83b544293be4946cb15eddded31a73c2a58fd8c312a28f97a6929d8498dbf269bd0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There was a breaking change in 6.3 that merges the EthMethod and Eth4337Methods. This pr fixes this. 
