### PR TITLE
ci: group Snaps dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,9 @@ updates:
     allow:
       - dependency-name: '@metamask/*'
     target-branch: 'main'
-    versioning-strategy: 'increase-if-necessary'
+    versioning-strategy: 'increase'
     open-pull-requests-limit: 10
+    groups:
+      snaps:
+        patterns:
+          - '@metamask/snaps-*'


### PR DESCRIPTION
This PR modifies the Dependabot configuration to group together updates for all Snaps dependencies. It also changes the `versioning-strategy` to `increase`.